### PR TITLE
Add single customer detail page

### DIFF
--- a/web/detail.html
+++ b/web/detail.html
@@ -1,0 +1,20 @@
+<!DOCTYPE html>
+<html lang="ja">
+<head>
+  <meta charset="UTF-8" />
+  <title>顧客詳細</title>
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" />
+</head>
+<body class="p-4">
+  <div class="container">
+    <h1 class="mb-3">顧客詳細</h1>
+    <table id="detail-table" class="table table-bordered">
+      <tbody></tbody>
+    </table>
+    <div id="history" class="mb-3"></div>
+    <a href="index.html" class="btn btn-secondary">戻る</a>
+  </div>
+
+  <script src="detail.js"></script>
+</body>
+</html>

--- a/web/detail.js
+++ b/web/detail.js
@@ -1,0 +1,39 @@
+const API = 'https://example.com/api';
+
+async function loadDetail() {
+  const params = new URLSearchParams(location.search);
+  const id = params.get('id');
+  if (!id) return;
+
+  try {
+    const res = await fetch(API + '/customers/' + id);
+    const data = await res.json();
+    const item = data.Item || data;
+
+    const tbody = document.querySelector('#detail-table tbody');
+    tbody.innerHTML = '';
+    for (const [key, val] of Object.entries(item)) {
+      if (key === 'history') continue;
+      const tr = document.createElement('tr');
+      tr.innerHTML = `<th>${key}</th><td>${val ?? ''}</td>`;
+      tbody.appendChild(tr);
+    }
+
+    const hist = document.getElementById('history');
+    hist.innerHTML = '';
+    if (item.history) {
+      hist.innerHTML = '<h4>履歴</h4>';
+      const ul = document.createElement('ul');
+      for (const [d, note] of Object.entries(item.history)) {
+        const li = document.createElement('li');
+        li.textContent = `${d}: ${note}`;
+        ul.appendChild(li);
+      }
+      hist.appendChild(ul);
+    }
+  } catch (e) {
+    console.error(e);
+  }
+}
+
+window.addEventListener('DOMContentLoaded', loadDetail);


### PR DESCRIPTION
## Summary
- add `detail.html` and `detail.js` under `web/`
- display a customer's fields and history based on `id` query parameter
- include a Back button to `index.html`
- load Bootstrap like the main page

## Testing
- `npm test` *(fails: Could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_684641e9743c832a92c3ca8233d6d2f6