### PR TITLE
Add dashboard metrics section

### DIFF
--- a/web/app.js
+++ b/web/app.js
@@ -3,6 +3,21 @@ const API = 'https://example.com/api';
 
 let currentItem = null;
 
+async function loadDashboard() {
+  const res = await fetch(API + '/customers');
+  const data = await res.json();
+  const customers = data.Items || data;
+
+  const total = customers.length;
+  const today = new Date().toISOString().split('T')[0];
+  const todayCount = customers.filter(c => (c.createdAt || '').startsWith(today)).length;
+  const unconfirmed = customers.filter(c => (c.status || '') === '未済').length;
+
+  document.getElementById('d-total').textContent = total;
+  document.getElementById('d-today').textContent = todayCount;
+  document.getElementById('d-unconfirmed').textContent = unconfirmed;
+}
+
 async function loadCustomers() {
   const q = document.getElementById('search-box').value;
   const res = await fetch(API + '/customers');
@@ -101,4 +116,5 @@ function hideForm() {
 }
 
 // 初期表示
+loadDashboard();
 loadCustomers();

--- a/web/index.html
+++ b/web/index.html
@@ -12,6 +12,39 @@
     <div class="row">
       <!-- Dashboard Area -->
       <div id="dashboard" class="col-md-8 mb-3" style="height:600px; overflow:auto;">
+        <div id="dashboard-metrics" class="row mb-3">
+          <div class="col">
+            <a href="search.html" class="text-decoration-none">
+              <div class="card text-center">
+                <div class="card-body">
+                  <div>総問い合わせ</div>
+                  <div id="d-total" class="fs-3">0</div>
+                </div>
+              </div>
+            </a>
+          </div>
+          <div class="col">
+            <a href="search.html" class="text-decoration-none">
+              <div class="card text-center">
+                <div class="card-body">
+                  <div>本日の件数</div>
+                  <div id="d-today" class="fs-3">0</div>
+                </div>
+              </div>
+            </a>
+          </div>
+          <div class="col">
+            <a href="search.html" class="text-decoration-none">
+              <div class="card text-center">
+                <div class="card-body">
+                  <div>未済</div>
+                  <div id="d-unconfirmed" class="fs-3">0</div>
+                </div>
+              </div>
+            </a>
+          </div>
+        </div>
+
         <div class="mb-3 d-flex gap-2">
           <input
             type="text"


### PR DESCRIPTION
## Summary
- add a metrics row to `index.html` with links to the search page
- compute totals in `app.js` via new `loadDashboard()` and show counts

## Testing
- `node`/npm tests not present – none run

------
https://chatgpt.com/codex/tasks/task_e_684645e61220832aac2be5f8ec8ab753