### PR TITLE
Implement basic pagination for customers

### DIFF
--- a/web/index.html
+++ b/web/index.html
@@ -69,6 +69,12 @@
           <tbody></tbody>
         </table>
 
+        <div class="d-flex justify-content-between align-items-center mb-3">
+          <button id="prev-btn" class="btn btn-outline-primary btn-sm" onclick="prevPage()">前へ</button>
+          <span id="page-info">1 / 1</span>
+          <button id="next-btn" class="btn btn-outline-primary btn-sm" onclick="nextPage()">次へ</button>
+        </div>
+
         <div id="form-area" class="card p-3" style="display:none">
           <input id="f-id" type="hidden" />
           <div class="mb-2">名前: <input id="f-name" class="form-control" /></div>


### PR DESCRIPTION
## Summary
- limit customer list to 10 rows per page
- add next/previous controls to navigate pages
- show current page number below the table

## Testing
- `npm test` *(fails: package.json missing)*

------
https://chatgpt.com/codex/tasks/task_e_684646d5a734832aa570c1bff47609d7