### PR TITLE
Set API base URL to local server

### DIFF
--- a/web/app.js
+++ b/web/app.js
@@ -1,5 +1,6 @@
-// APIエンドポイント（後で差し替える）
-const API = '';
+// APIエンドポイント
+// Express サーバーを利用する場合はローカルの URL を指定する
+const API = 'http://localhost:3000';
 
 let currentItem = null;
 let currentPage = 1;


### PR DESCRIPTION
## Summary
- point `API` constant in `web/app.js` to the local Express server

## Testing
- `npm start` *(fails: Cannot find module 'express')*

------
https://chatgpt.com/codex/tasks/task_e_68464a489560832a9d28b3e231dc5e33