### PR TITLE
Fix status handling for saveCustomer

### DIFF
--- a/web/app.js
+++ b/web/app.js
@@ -112,15 +112,36 @@ async function saveCustomer() {
     history[today] = note;
   }
 
+  let status;
+  if (id) {
+    if (currentItem && currentItem.id === id) {
+      status = currentItem.status;
+    } else {
+      try {
+        const res = await fetch(API + '/customers/' + id);
+        if (res.ok) {
+          const data = await res.json();
+          status = (data.Item || data).status;
+        }
+      } catch (e) {
+        console.error(e);
+      }
+    }
+  } else {
+    status = '未済';
+  }
+
   const body = {
     name: document.getElementById('f-name').value,
     email: document.getElementById('f-email').value,
     category: document.getElementById('f-category').value,
     phoneNumber: document.getElementById('f-phone').value,
-    status: id && currentItem ? currentItem.status : '未済',
     history,
     bikes: []
   };
+  if (status !== undefined) {
+    body.status = status;
+  }
   const method = id ? 'PUT' : 'POST';
   const url = id ? API + '/customers/' + id : API + '/customers';
   await fetch(url, { method, body: JSON.stringify(body) });


### PR DESCRIPTION
## Summary
- maintain existing status when editing customers
- assign `'未済'` only when creating a new record

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68464bbd4378832a90b0f2728cd3bf75