### PR TITLE
Use origin-based API URL in JS

### DIFF
--- a/web/app.js
+++ b/web/app.js
@@ -1,6 +1,8 @@
 // APIエンドポイント
-// Express サーバーを利用する場合はローカルの URL を指定する
-const API = 'http://localhost:3000';
+// API は環境変数(API_URL)または現在のオリジンを利用する
+const API = (typeof window !== 'undefined' && window.API_URL) ||
+  (typeof process !== 'undefined' && process.env && process.env.API_URL) ||
+  window.location.origin;
 
 let currentItem = null;
 let currentPage = 1;

--- a/web/detail.js
+++ b/web/detail.js
@@ -1,5 +1,8 @@
 // Express サーバーを利用する場合はローカルの URL を指定する
-const API = 'http://localhost:3000';
+// API は環境変数(API_URL)または現在のオリジンを利用する
+const API = (typeof window !== 'undefined' && window.API_URL) ||
+  (typeof process !== 'undefined' && process.env && process.env.API_URL) ||
+  window.location.origin;
 
 async function loadDetail() {
   const params = new URLSearchParams(location.search);

--- a/web/search.js
+++ b/web/search.js
@@ -1,5 +1,8 @@
 // Express サーバーを利用する場合はローカルの URL を指定する
-const API = 'http://localhost:3000';
+// API は環境変数(API_URL)または現在のオリジンを利用する
+const API = (typeof window !== 'undefined' && window.API_URL) ||
+  (typeof process !== 'undefined' && process.env && process.env.API_URL) ||
+  window.location.origin;
 
 function getKey(c) {
   return c.createdAt || c.id || 0;


### PR DESCRIPTION
## Summary
- make API URL configurable using window origin or API_URL env var

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_684663323a14832a8485c7d7aa8208fa