### PR TITLE
Update dashboard metrics to use date

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ but now it uses `window.location.origin` so the host is detected automatically.
 
 ### ✅ ダッシュボード指標 / Dashboard Metrics
 - **総問い合わせ / Total Inquiries**: 顧客データの総件数 / Total customer entries  
-- **本日の件数 / Today’s Count**: Entries with `createdAt` set to today  
+- **本日の件数 / Today’s Count**: Entries where `date` equals today
 - **未済 / Pending**: Entries with `status` = "未済" (unresolved)
 
 ### 🔁 ページネーション / Pagination  

--- a/web/app.js
+++ b/web/app.js
@@ -14,8 +14,13 @@ async function loadDashboard() {
   const customers = data.Items || data;
 
   const total = customers.length;
-  const today = new Date().toISOString().split('T')[0];
-  const todayCount = customers.filter(c => (c.createdAt || '').startsWith(today)).length;
+  const today = new Date().toISOString().split('T')[0].replace(/-/g, '/');
+  const todayKey = today.replace(/\//g, '');
+  const todayCount = customers.filter(c => {
+    if (c.date) return c.date === today;
+    if (c.order_id) return c.order_id.slice(0, 8) === todayKey;
+    return false;
+  }).length;
   const unconfirmed = customers.filter(c => (c.status || '') === '未済').length;
 
   document.getElementById('d-total').textContent = total;

--- a/web/search.js
+++ b/web/search.js
@@ -5,7 +5,9 @@ const API = (typeof window !== 'undefined' && window.API_URL) ||
   window.location.origin;
 
 function getKey(c) {
-  return c.createdAt || c.id || 0;
+  if (c.order_id) return c.order_id.slice(0, 14);
+  if (c.date) return c.date.replace(/\//g, '');
+  return c.id || 0;
 }
 
 async function searchCustomers() {


### PR DESCRIPTION
## Summary
- update README wording for Today's Count
- use `date` or order ID to calculate today's dashboard metric
- sort search results using `date`/`order_id` instead of `createdAt`

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6846707ae2ec832a832ab206e4883faf