### PR TITLE
Unify note handling via history field

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Bootstrap を利用しているため、見た目もある程度整っていま�
 It uses Bootstrap for basic styling and layout.
 
 新規追加時には履歴メモを入力でき、編集画面では登録済みの履歴を確認できます。  
-You can input notes when adding new entries, and view history in the edit form.
+You can input notes when adding new entries, and view the saved history in the edit form.
 
 顧客テーブルとフォームの電話項目は「電話番号（Phone Number）」と表記されています。  
 The phone number field is labeled as "電話番号 (Phone Number)" in the table and form.
@@ -88,7 +88,7 @@ Customer data is stored in the DynamoDB table `kokyakukanri_TBL`.
 | `date`     | Handled date in `yyyy/mm/dd`                  | `2024/01/01`                      |
 | `staff`    | Person in charge                              | `佐藤`                             |
 | `phone`    | Phone number                                  | `090-1234-5678`                   |
-| `note`     | Additional notes                              | `特になし`                         |
+| `history`  | Notes history object (`YYYY-MM-DD`: text)     | `{ "2024-01-01": "First call" }` |
 
 
 ---

--- a/app.js
+++ b/app.js
@@ -52,7 +52,7 @@ app.post('/customers', async (req, res) => {
     date: req.body.date || new Date().toISOString().split('T')[0].replace(/-/g, '/'),
     staff: req.body.staff || '',
     phone: req.body.phoneNumber || req.body.phone || '',
-    note: req.body.note || ''
+    history: req.body.history || {}
   };
   try {
     await ddb.send(new PutCommand({ TableName: TABLE, Item: item }));
@@ -90,7 +90,7 @@ app.put('/customers/:id', async (req, res) => {
     date: req.body.date || '',
     staff: req.body.staff || '',
     phone: req.body.phoneNumber || req.body.phone || '',
-    note: req.body.note || ''
+    history: req.body.history || {}
   };
   try {
     await ddb.send(new PutCommand({ TableName: TABLE, Item: item }));

--- a/web/app.js
+++ b/web/app.js
@@ -80,7 +80,7 @@ function showAddForm() {
   document.getElementById('f-email').value = '';
   document.getElementById('f-category').value = '';
   document.getElementById('f-phone').value = '';
-  document.getElementById('f-note').value = '';
+  document.getElementById('f-history-note').value = '';
   document.getElementById('history-view').innerHTML = '';
   document.getElementById('form-area').style.display = 'block';
 }
@@ -95,7 +95,7 @@ async function editCustomer(id) {
   document.getElementById('f-email').value = item.email;
   document.getElementById('f-category').value = item.category;
   document.getElementById('f-phone').value = item.phoneNumber || item.phone;
-  document.getElementById('f-note').value = '';
+  document.getElementById('f-history-note').value = '';
   const hv = document.getElementById('history-view');
   hv.innerHTML = '';
   if (item.history) {
@@ -110,7 +110,7 @@ async function editCustomer(id) {
 
 async function saveCustomer() {
   const id = document.getElementById('f-order_id').value;
-  const note = document.getElementById('f-note').value.trim();
+  const note = document.getElementById('f-history-note').value.trim();
   const today = new Date().toISOString().split('T')[0];
   let history = {};
   if (id && currentItem && currentItem.history) {

--- a/web/detail.js
+++ b/web/detail.js
@@ -23,6 +23,7 @@ async function loadDetail() {
       tbody.appendChild(tr);
     }
 
+    // Display note history
     const hist = document.getElementById('history');
     hist.innerHTML = '';
     if (item.history) {

--- a/web/index.html
+++ b/web/index.html
@@ -104,7 +104,7 @@
             <div class="mb-2">メール: <input id="f-email" class="form-control" /></div>
             <div class="mb-2">種別: <input id="f-category" class="form-control" /></div>
             <div class="mb-2">電話番号: <input id="f-phone" class="form-control" /></div>
-            <div class="mb-2">履歴: <textarea id="f-note" class="form-control"></textarea></div>
+            <div class="mb-2">履歴: <textarea id="f-history-note" class="form-control"></textarea></div>
             <div id="history-view" class="mb-2"></div>
             <div>
               <button class="btn btn-primary" onclick="saveCustomer()">保存</button>


### PR DESCRIPTION
## Summary
- store customer notes in a `history` field on create/update
- show the same field in the frontend
- rename the form textarea ID for clarity
- document the `history` field in README

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_684673a82d2c832a9b05e1895cad7d08