### PR TITLE
Update README server instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,9 +68,10 @@ Steps to start the server using Node.js and Express:
 npm install
 npm start
 ```
-
-ブラウザでサーバーのホスト (例: http://54.95.8.178/) にアクセスしてください。
-Access the server host in your browser, e.g. http://54.95.8.178/.
+Expressサーバーは `server.js` (1-6 行目) でポート3000を listen します。
+The Express server listens on port 3000 by default (see server.js lines 1–6).
+ブラウザでサーバーのホスト (例: http://54.95.8.178:3000/) にアクセスしてください。`index.html` も同じホスト・ポートで開くか `API_URL` を設定してください。
+Access the server host in your browser, e.g. http://54.95.8.178:3000/. Because the frontend uses `window.location.origin`, open `index.html` from the same host and port or set `API_URL`.
 
 データは DynamoDB テーブル `kokyakukanri_TBL` に保存されます。
 Customer data is stored in the DynamoDB table `kokyakukanri_TBL`.


### PR DESCRIPTION
## Summary
- mention default port 3000 for Express server
- use example host with `:3000`
- clarify that frontend uses `window.location.origin`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6846821b8cdc832aad7abd15beb18d14