### PR TITLE
Add debug page and clarify server port

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,8 +69,10 @@ npm install
 npm start
 ```
 
-ブラウザでサーバーのホスト (例: http://54.95.8.178/) にアクセスしてください。
-Access the server host in your browser, e.g. http://54.95.8.178/.
+サーバーは `server.js` で `process.env.PORT || 3000` を使用して起動します。
+ブラウザではホストとポート (例: http://54.95.8.178:3000/) にアクセスしてください。
+Access the server host and port in your browser, e.g. http://54.95.8.178:3000/.
+フロントエンドは `window.location.origin` を利用するため、`index.html` を同じホスト・ポートで開くか `API_URL` を指定してください。
 
 データは DynamoDB テーブル `kokyakukanri_TBL` に保存されます。
 Customer data is stored in the DynamoDB table `kokyakukanri_TBL`.

--- a/web/debug.html
+++ b/web/debug.html
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<html lang="ja">
+<head>
+  <meta charset="UTF-8">
+  <title>Debug Customers</title>
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" />
+</head>
+<body class="p-4">
+  <div class="container">
+    <h1 class="mb-3">Debug: All Customers</h1>
+    <pre id="data">Loading...</pre>
+    <a href="index.html" class="btn btn-secondary mt-3">Back</a>
+  </div>
+  <script src="debug.js"></script>
+</body>
+</html>

--- a/web/debug.js
+++ b/web/debug.js
@@ -1,0 +1,18 @@
+const API = (typeof window !== 'undefined' && window.API_URL) ||
+  (typeof process !== 'undefined' && process.env && process.env.API_URL) ||
+  window.location.origin;
+
+async function loadDebug() {
+  const out = document.getElementById('data');
+  try {
+    const res = await fetch(API + '/customers');
+    const data = await res.json();
+    const customers = data.Items || data;
+    out.textContent = JSON.stringify(customers, null, 2);
+  } catch (e) {
+    console.error(e);
+    out.textContent = 'Failed to load data';
+  }
+}
+
+window.addEventListener('DOMContentLoaded', loadDebug);


### PR DESCRIPTION
## Summary
- document server port and origin rules in README
- add `debug.html` and `debug.js` for viewing all customers

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68467edd8ecc832a82a20d2d3f7f80fe