### PR TITLE
Fix DynamoDB client region

### DIFF
--- a/app.js
+++ b/app.js
@@ -13,7 +13,8 @@ const {
 
 const TABLE = process.env.TABLE_NAME || 'kokyakukanri_TBL';
 
-const client = new DynamoDBClient({});
+const region = process.env.AWS_REGION || 'ap-northeast-1';
+const client = new DynamoDBClient({ region });
 const ddb = DynamoDBDocumentClient.from(client);
 
 const app = express();


### PR DESCRIPTION
## Summary
- set the DynamoDB client region using the `AWS_REGION` env var or default to `ap-northeast-1`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6846f8bac864832a88d51515cecf0a2d