### PR TITLE
Add fields and JST support

### DIFF
--- a/app.js
+++ b/app.js
@@ -30,7 +30,7 @@ function getDateKey(item) {
 
 // 注文IDを生成する関数（日時＋ランダム文字列）
 function genOrderId() {
-  const now = new Date();
+  const now = new Date(Date.now() + 9 * 60 * 60 * 1000);
   const ymdhms = now.toISOString().replace(/[-T:Z.]/g, '').slice(0, 14);
   const rand = Math.random().toString(36).substring(2, 6);
   return `${ymdhms}-${rand}`;
@@ -111,9 +111,10 @@ app.post('/customers', async (req, res) => {
     status: req.body.status || '未済',
     email: req.body.email || '',
     name: req.body.name || '',
+    kana: req.body.kana || '',
     type: req.body.category || req.body.type || '',
     details: req.body.details || '',
-    date: req.body.date || new Date().toISOString().split('T')[0].replace(/-/g, '/'),
+    date: req.body.date || new Date(Date.now() + 9 * 60 * 60 * 1000).toISOString().split('T')[0].replace(/-/g, '/'),
     staff: req.body.staff || '',
     phone: req.body.phoneNumber || req.body.phone || '',
     history: req.body.history || {}
@@ -149,6 +150,7 @@ app.put('/customers/:id', async (req, res) => {
     status: req.body.status || '未済',
     email: req.body.email || '',
     name: req.body.name || '',
+    kana: req.body.kana || '',
     type: req.body.category || req.body.type || '',
     details: req.body.details || '',
     date: req.body.date || '',

--- a/web/app.js
+++ b/web/app.js
@@ -14,7 +14,7 @@ async function loadDashboard() {
   const customers = data.Items || data;
 
   const total = customers.length;
-  const today = new Date().toISOString().split('T')[0].replace(/-/g, '/');
+  const today = new Date(Date.now() + 9 * 60 * 60 * 1000).toISOString().split('T')[0].replace(/-/g, '/');
   const todayKey = today.replace(/\//g, '');
   const todayCount = customers.filter(c => {
     if (c.date) return c.date === today;
@@ -77,9 +77,12 @@ function showAddForm() {
   currentItem = null;
   document.getElementById('f-order_id').value = '';
   document.getElementById('f-name').value = '';
+  document.getElementById('f-kana').value = '';
   document.getElementById('f-email').value = '';
   document.getElementById('f-category').value = '';
   document.getElementById('f-phone').value = '';
+  document.getElementById('f-details').value = '';
+  document.getElementById('f-staff').value = '';
   document.getElementById('f-history-note').value = '';
   document.getElementById('history-view').innerHTML = '';
   document.getElementById('form-area').style.display = 'block';
@@ -92,9 +95,12 @@ async function editCustomer(id) {
   currentItem = item;
   document.getElementById('f-order_id').value = item.order_id;
   document.getElementById('f-name').value = item.name;
+  document.getElementById('f-kana').value = item.kana || '';
   document.getElementById('f-email').value = item.email;
   document.getElementById('f-category').value = item.category;
   document.getElementById('f-phone').value = item.phoneNumber || item.phone;
+  document.getElementById('f-details').value = item.details || '';
+  document.getElementById('f-staff').value = item.staff || '';
   document.getElementById('f-history-note').value = '';
   const hv = document.getElementById('history-view');
   hv.innerHTML = '';
@@ -111,7 +117,7 @@ async function editCustomer(id) {
 async function saveCustomer() {
   const id = document.getElementById('f-order_id').value;
   const note = document.getElementById('f-history-note').value.trim();
-  const today = new Date().toISOString().split('T')[0];
+  const today = new Date(Date.now() + 9 * 60 * 60 * 1000).toISOString().split('T')[0];
   let history = {};
   if (id && currentItem && currentItem.history) {
     history = { ...currentItem.history };
@@ -141,9 +147,12 @@ async function saveCustomer() {
 
   const body = {
     name: document.getElementById('f-name').value,
+    kana: document.getElementById('f-kana').value,
     email: document.getElementById('f-email').value,
     category: document.getElementById('f-category').value,
     phoneNumber: document.getElementById('f-phone').value,
+    details: document.getElementById('f-details').value,
+    staff: document.getElementById('f-staff').value,
     history,
     bikes: []
   };

--- a/web/index.html
+++ b/web/index.html
@@ -100,11 +100,14 @@
         <div class="col-12">
           <div id="form-area" class="card p-3" style="display:none">
             <input id="f-order_id" type="hidden" />
-            <div class="mb-2">名前: <input id="f-name" class="form-control" /></div>
-            <div class="mb-2">メール: <input id="f-email" class="form-control" /></div>
-            <div class="mb-2">種別: <input id="f-category" class="form-control" /></div>
-            <div class="mb-2">電話番号: <input id="f-phone" class="form-control" /></div>
-            <div class="mb-2">履歴: <textarea id="f-history-note" class="form-control"></textarea></div>
+              <div class="mb-2">名前: <input id="f-name" class="form-control" /></div>
+              <div class="mb-2">カナ: <input id="f-kana" class="form-control" /></div>
+              <div class="mb-2">メール: <input id="f-email" class="form-control" /></div>
+              <div class="mb-2">種別: <input id="f-category" class="form-control" /></div>
+              <div class="mb-2">電話番号: <input id="f-phone" class="form-control" /></div>
+              <div class="mb-2">詳細: <input id="f-details" class="form-control" /></div>
+              <div class="mb-2">担当: <input id="f-staff" class="form-control" /></div>
+              <div class="mb-2">履歴: <textarea id="f-history-note" class="form-control"></textarea></div>
             <div id="history-view" class="mb-2"></div>
             <div>
               <button class="btn btn-primary" onclick="saveCustomer()">保存</button>


### PR DESCRIPTION
## Summary
- add name kana, details, and staff inputs in the UI
- pass kana/details/staff from UI to API
- store kana, details and staff in the backend
- generate dates and IDs using JST (+9h)

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68470108bb54832a9c5d73e19d9cc620