### PR TITLE
Add flexible detailed filtering

### DIFF
--- a/web/completed.html
+++ b/web/completed.html
@@ -1,0 +1,21 @@
+<!DOCTYPE html>
+<html lang="ja">
+<head>
+  <meta charset="UTF-8" />
+  <title>完了済み一覧</title>
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootswatch@5.3.0/dist/flatly/bootstrap.min.css" />
+</head>
+<body class="p-4">
+  <div class="container">
+    <h1 class="mb-3">完了済み一覧</h1>
+    <table id="done-table" class="table table-striped">
+      <thead>
+        <tr><th>名前</th><th>電話番号</th><th>状態</th><th>詳細</th></tr>
+      </thead>
+      <tbody></tbody>
+    </table>
+    <a href="index.html" class="btn btn-secondary">戻る</a>
+  </div>
+  <script src="completed.js"></script>
+</body>
+</html>

--- a/web/completed.js
+++ b/web/completed.js
@@ -1,0 +1,22 @@
+const API = (typeof window !== 'undefined' && window.API_URL) ||
+  (typeof process !== 'undefined' && process.env && process.env.API_URL) ||
+  window.location.origin;
+
+async function loadCompleted() {
+  const res = await fetch(API + '/customers');
+  const data = await res.json();
+  const customers = (data.Items || data).filter(c => (c.status || '') === '済');
+  const tbody = document.querySelector('#done-table tbody');
+  tbody.innerHTML = '';
+  customers.forEach(c => {
+    const tr = document.createElement('tr');
+    tr.innerHTML = `
+      <td>${c.name}</td>
+      <td>${c.phoneNumber || c.phone || ''}</td>
+      <td>${c.status}</td>
+      <td><a href="detail.html?id=${c.order_id}">詳細</a></td>`;
+    tbody.appendChild(tr);
+  });
+}
+
+window.addEventListener('DOMContentLoaded', loadCompleted);

--- a/web/debug.html
+++ b/web/debug.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <title>Debug Customers</title>
-  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" />
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootswatch@5.3.0/dist/flatly/bootstrap.min.css" />
 </head>
 <body class="p-4">
   <div class="container">

--- a/web/detail.html
+++ b/web/detail.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8" />
   <title>顧客詳細</title>
-  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" />
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootswatch@5.3.0/dist/flatly/bootstrap.min.css" />
 </head>
 <body class="p-4">
   <div class="container">

--- a/web/detail.js
+++ b/web/detail.js
@@ -16,12 +16,25 @@ async function loadDetail() {
 
     const tbody = document.querySelector('#detail-table tbody');
     tbody.innerHTML = '';
-    for (const [key, val] of Object.entries(item)) {
-      if (key === 'history') continue;
-      const tr = document.createElement('tr');
-      tr.innerHTML = `<th>${key}</th><td>${val ?? ''}</td>`;
-      tbody.appendChild(tr);
-    }
+    const fields = [
+      ['order_id', '注文ID'],
+      ['date', '日付'],
+      ['name', '名前（顧客名）'],
+      ['status', 'ステータス'],
+      ['phone', '電話番号'],
+      ['email', 'メールアドレス'],
+      ['type', 'お問い合わせ種別'],
+      ['details', 'お問い合わせいただいてるバイク名']
+    ];
+    fields.forEach(([key, label]) => {
+      let val = item[key];
+      if (key === 'phone') val = item.phoneNumber || item.phone;
+      if (val) {
+        const tr = document.createElement('tr');
+        tr.innerHTML = `<th>${label}</th><td>${val}</td>`;
+        tbody.appendChild(tr);
+      }
+    });
 
     // Display note history
     const hist = document.getElementById('history');

--- a/web/index.html
+++ b/web/index.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8" />
   <title>顧客管理サンプル</title>
-  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" />
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootswatch@5.3.0/dist/flatly/bootstrap.min.css" />
 </head>
 <body class="p-4">
   <div class="container">
@@ -58,6 +58,16 @@
               </div>
             </a>
           </div>
+          <div class="col">
+            <a href="completed.html" class="text-decoration-none">
+              <div class="card text-center">
+                <div class="card-body">
+                  <div>完了済み</div>
+                  <div id="d-completed" class="fs-3">0</div>
+                </div>
+              </div>
+            </a>
+          </div>
         </div>
 
 
@@ -106,6 +116,12 @@
               <div class="mb-2">種別: <input id="f-category" class="form-control" /></div>
               <div class="mb-2">電話番号: <input id="f-phone" class="form-control" /></div>
               <div class="mb-2">詳細: <input id="f-details" class="form-control" /></div>
+              <div class="mb-2">状態:
+                <select id="f-status" class="form-select">
+                  <option value="未済">未済</option>
+                  <option value="済">済</option>
+                </select>
+              </div>
               <div class="mb-2">担当: <input id="f-staff" class="form-control" /></div>
               <div class="mb-2">履歴: <textarea id="f-history-note" class="form-control"></textarea></div>
             <div id="history-view" class="mb-2"></div>

--- a/web/search.html
+++ b/web/search.html
@@ -3,22 +3,46 @@
 <head>
   <meta charset="UTF-8" />
   <title>詳細検索</title>
-  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" />
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootswatch@5.3.0/dist/flatly/bootstrap.min.css" />
 </head>
 <body class="p-4">
   <div class="container">
     <h1 class="mb-3">詳細検索</h1>
+    <div class="mb-3">
+      <label class="form-label">注文ID</label>
+      <input id="s-order" class="form-control" />
+    </div>
+    <div class="mb-3">
+      <label class="form-label">日付</label>
+      <input id="s-date" type="date" class="form-control" />
+    </div>
+    <div class="mb-3">
+      <label class="form-label">名前</label>
+      <input id="s-name" class="form-control" />
+    </div>
+    <div class="mb-3">
+      <label class="form-label">電話番号</label>
+      <input id="s-phone" class="form-control" />
+    </div>
     <div class="mb-3">
       <label class="form-label">メール</label>
       <input id="s-email" class="form-control" />
     </div>
     <div class="mb-3">
       <label class="form-label">状態</label>
-      <input id="s-status" class="form-control" />
+      <select id="s-status" class="form-select">
+        <option value="">--</option>
+        <option value="未済">未済</option>
+        <option value="済">済</option>
+      </select>
     </div>
     <div class="mb-3">
       <label class="form-label">種別</label>
       <input id="s-category" class="form-control" />
+    </div>
+    <div class="mb-3">
+      <label class="form-label">詳細</label>
+      <input id="s-details" class="form-control" />
     </div>
     <div class="mb-3">
       <label class="form-label">並び替え</label>

--- a/web/search.js
+++ b/web/search.js
@@ -11,9 +11,14 @@ function getKey(c) {
 }
 
 async function searchCustomers() {
+  const order = document.getElementById('s-order').value.trim();
+  const date = document.getElementById('s-date').value.trim();
+  const name = document.getElementById('s-name').value.trim();
+  const phone = document.getElementById('s-phone').value.trim();
   const email = document.getElementById('s-email').value.trim();
   const status = document.getElementById('s-status').value.trim();
   const category = document.getElementById('s-category').value.trim();
+  const details = document.getElementById('s-details').value.trim();
   const sort = document.getElementById('s-sort').value;
 
   const res = await fetch(API + '/customers');
@@ -21,9 +26,14 @@ async function searchCustomers() {
   let customers = data.Items || data;
 
   customers = customers.filter(c =>
+    (!order || (c.order_id || '').includes(order)) &&
+    (!date || (c.date || '').includes(date)) &&
+    (!name || (c.name || '').includes(name)) &&
+    (!phone || (c.phone || c.phoneNumber || '').includes(phone)) &&
     (!email || (c.email || '').includes(email)) &&
     (!status || (c.status || '') === status) &&
-    (!category || (c.category || '') === category)
+    (!category || (c.category || '') === category) &&
+    (!details || (c.details || '').includes(details))
   );
 
   customers.sort((a, b) => {


### PR DESCRIPTION
## Summary
- enable filtering by order id, date, name, phone, email, type, status and details
- update search.html with new inputs for all fields

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6847040303b0832ab59a9e70bf372c32