### PR TITLE
Improve dashboard links and add filtered lists

### DIFF
--- a/web/app.js
+++ b/web/app.js
@@ -52,7 +52,7 @@ async function loadCustomers(page = 1) {
   customers.slice(start, start + PAGE_SIZE).forEach(c => {
     const tr = document.createElement('tr');
     tr.innerHTML = `
-      <td>${c.name}</td>
+      <td><a href="detail.html?id=${c.order_id}">${c.name}</a></td>
       <td>${c.phoneNumber || c.phone || ''}</td>
       <td>
         ${c.status || ''}

--- a/web/index.html
+++ b/web/index.html
@@ -27,7 +27,7 @@
     <div class="row mb-3">
       <!-- Dashboard Area -->
       <div id="dashboard" class="col-md-7" style="height:600px; overflow:auto; flex:0 0 70%; max-width:70%;">
-        <div id="dashboard-metrics" class="row mb-3">
+        <div id="dashboard-metrics" class="row row-cols-2 g-2 mb-3">
           <div class="col">
             <a href="search.html" class="text-decoration-none">
               <div class="card text-center">
@@ -39,7 +39,7 @@
             </a>
           </div>
           <div class="col">
-            <a href="search.html" class="text-decoration-none">
+            <a href="today.html" class="text-decoration-none">
               <div class="card text-center">
                 <div class="card-body">
                   <div>本日の件数</div>
@@ -49,7 +49,7 @@
             </a>
           </div>
           <div class="col">
-            <a href="search.html" class="text-decoration-none">
+            <a href="pending.html" class="text-decoration-none">
               <div class="card text-center">
                 <div class="card-body">
                   <div>未済</div>
@@ -89,7 +89,7 @@
               <tr>
                 <th>名前</th>
                 <th>電話番号</th>
-                <th>状態</th>
+                <th>ステータス</th>
                 <th>操作</th>
                 <th>詳細</th>
               </tr>
@@ -117,7 +117,7 @@
               <div class="mb-2">種別: <input id="f-category" class="form-control" /></div>
               <div class="mb-2">電話番号: <input id="f-phone" class="form-control" /></div>
               <div class="mb-2">詳細: <input id="f-details" class="form-control" /></div>
-              <div class="mb-2">状態:
+              <div class="mb-2">ステータス:
                 <select id="f-status" class="form-select">
                   <option value="未済">未済</option>
                   <option value="済">済</option>

--- a/web/pending.html
+++ b/web/pending.html
@@ -1,0 +1,21 @@
+<!DOCTYPE html>
+<html lang="ja">
+<head>
+  <meta charset="UTF-8" />
+  <title>未済一覧</title>
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootswatch@5.3.0/dist/flatly/bootstrap.min.css" />
+</head>
+<body class="p-4">
+  <div class="container">
+    <h1 class="mb-3">未済一覧</h1>
+    <table id="pending-table" class="table table-striped">
+      <thead>
+        <tr><th>名前</th><th>電話番号</th><th>ステータス</th><th>詳細</th></tr>
+      </thead>
+      <tbody></tbody>
+    </table>
+    <a href="index.html" class="btn btn-secondary">戻る</a>
+  </div>
+  <script src="pending.js"></script>
+</body>
+</html>

--- a/web/pending.js
+++ b/web/pending.js
@@ -8,36 +8,23 @@ function getKey(c) {
   return 0;
 }
 
-async function loadCompleted() {
+async function loadPending() {
   const res = await fetch(API + '/customers');
   const data = await res.json();
-  let customers = (data.Items || data).filter(c => (c.status || '') === '済');
+  let customers = (data.Items || data).filter(c => (c.status || '') === '未済');
   customers.sort((a, b) => getKey(b) - getKey(a));
 
-  const tbody = document.querySelector('#done-table tbody');
+  const tbody = document.querySelector('#pending-table tbody');
   tbody.innerHTML = '';
   customers.forEach(c => {
     const tr = document.createElement('tr');
     tr.innerHTML = `
       <td><a href="detail.html?id=${c.order_id}">${c.name}</a></td>
       <td>${c.phoneNumber || c.phone || ''}</td>
-      <td>
-        ${c.status}
-        <button class="btn btn-sm btn-outline-secondary ms-2" onclick="toggleStatus('${c.order_id}', '${c.status || ''}')">切替</button>
-      </td>
+      <td>${c.status || ''}</td>
       <td><a href="detail.html?id=${c.order_id}">詳細</a></td>`;
     tbody.appendChild(tr);
   });
 }
 
-async function toggleStatus(id, current) {
-  const newStatus = current === '済' ? '未済' : '済';
-  await fetch(API + '/customers/' + id, {
-    method: 'PUT',
-    headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify({ status: newStatus })
-  });
-  loadCompleted();
-}
-
-window.addEventListener('DOMContentLoaded', loadCompleted);
+window.addEventListener('DOMContentLoaded', loadPending);

--- a/web/search.html
+++ b/web/search.html
@@ -57,7 +57,7 @@
     </div>
     <table id="result-table" class="table table-striped">
       <thead>
-        <tr><th>名前</th><th>メール</th><th>種別</th><th>状態</th></tr>
+        <tr><th>名前</th><th>メール</th><th>種別</th><th>状態</th><th>詳細</th></tr>
       </thead>
       <tbody></tbody>
     </table>

--- a/web/search.js
+++ b/web/search.js
@@ -51,10 +51,11 @@ async function searchCustomers() {
   customers.forEach(c => {
     const tr = document.createElement('tr');
     tr.innerHTML = `
-      <td>${c.name}</td>
+      <td><a href="detail.html?id=${c.order_id}">${c.name}</a></td>
       <td>${c.email || ''}</td>
       <td>${c.category || ''}</td>
-      <td>${c.status || ''}</td>`;
+      <td>${c.status || ''}</td>
+      <td><a href="detail.html?id=${c.order_id}">詳細</a></td>`;
     tbody.appendChild(tr);
   });
 }

--- a/web/today.html
+++ b/web/today.html
@@ -1,0 +1,21 @@
+<!DOCTYPE html>
+<html lang="ja">
+<head>
+  <meta charset="UTF-8" />
+  <title>本日の問い合わせ</title>
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootswatch@5.3.0/dist/flatly/bootstrap.min.css" />
+</head>
+<body class="p-4">
+  <div class="container">
+    <h1 class="mb-3">本日の問い合わせ</h1>
+    <table id="today-table" class="table table-striped">
+      <thead>
+        <tr><th>名前</th><th>電話番号</th><th>ステータス</th><th>詳細</th></tr>
+      </thead>
+      <tbody></tbody>
+    </table>
+    <a href="index.html" class="btn btn-secondary">戻る</a>
+  </div>
+  <script src="today.js"></script>
+</body>
+</html>

--- a/web/today.js
+++ b/web/today.js
@@ -8,36 +8,30 @@ function getKey(c) {
   return 0;
 }
 
-async function loadCompleted() {
+async function loadToday() {
   const res = await fetch(API + '/customers');
   const data = await res.json();
-  let customers = (data.Items || data).filter(c => (c.status || '') === '済');
+  let customers = data.Items || data;
+  const today = new Date(Date.now() + 9 * 60 * 60 * 1000).toISOString().split('T')[0].replace(/-/g, '/');
+  const todayKey = today.replace(/\//g, '');
+  customers = customers.filter(c => {
+    if (c.date) return c.date === today;
+    if (c.order_id) return c.order_id.slice(0, 8) === todayKey;
+    return false;
+  });
   customers.sort((a, b) => getKey(b) - getKey(a));
 
-  const tbody = document.querySelector('#done-table tbody');
+  const tbody = document.querySelector('#today-table tbody');
   tbody.innerHTML = '';
   customers.forEach(c => {
     const tr = document.createElement('tr');
     tr.innerHTML = `
       <td><a href="detail.html?id=${c.order_id}">${c.name}</a></td>
       <td>${c.phoneNumber || c.phone || ''}</td>
-      <td>
-        ${c.status}
-        <button class="btn btn-sm btn-outline-secondary ms-2" onclick="toggleStatus('${c.order_id}', '${c.status || ''}')">切替</button>
-      </td>
+      <td>${c.status || ''}</td>
       <td><a href="detail.html?id=${c.order_id}">詳細</a></td>`;
     tbody.appendChild(tr);
   });
 }
 
-async function toggleStatus(id, current) {
-  const newStatus = current === '済' ? '未済' : '済';
-  await fetch(API + '/customers/' + id, {
-    method: 'PUT',
-    headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify({ status: newStatus })
-  });
-  loadCompleted();
-}
-
-window.addEventListener('DOMContentLoaded', loadCompleted);
+window.addEventListener('DOMContentLoaded', loadToday);


### PR DESCRIPTION
## Summary
- wrap dashboard metrics to show two per row
- link today's count to `today.html` and pending count to `pending.html`
- rename main table status column to `ステータス`
- link names in all tables to the detail view
- add `today.html`/`pending.html` pages and scripts
- add detail column to search results

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68470ccdbff4832abc81b34d701c3e3e