### PR TITLE
Remove order id field from search

### DIFF
--- a/web/search.html
+++ b/web/search.html
@@ -9,10 +9,6 @@
   <div class="container">
     <h1 class="mb-3">詳細検索</h1>
     <div class="mb-3">
-      <label class="form-label">注文ID</label>
-      <input id="s-order" class="form-control" />
-    </div>
-    <div class="mb-3">
       <label class="form-label">日付</label>
       <input id="s-date" type="date" class="form-control" />
     </div>
@@ -47,7 +43,7 @@
       </select>
     </div>
     <div class="mb-3">
-      <label class="form-label">詳細</label>
+      <label class="form-label">バイク機種名</label>
       <input id="s-details" class="form-control" />
     </div>
     <div class="mb-3">

--- a/web/search.js
+++ b/web/search.js
@@ -11,8 +11,8 @@ function getKey(c) {
 }
 
 async function searchCustomers() {
-  const order = document.getElementById('s-order').value.trim();
-  const date = document.getElementById('s-date').value.trim();
+  const dateInput = document.getElementById('s-date').value.trim();
+  const date = dateInput ? dateInput.replace(/-/g, '/') : '';
   const name = document.getElementById('s-name').value.trim();
   const phone = document.getElementById('s-phone').value.trim();
   const email = document.getElementById('s-email').value.trim();
@@ -26,7 +26,6 @@ async function searchCustomers() {
   let customers = data.Items || data;
 
   customers = customers.filter(c =>
-    (!order || (c.order_id || '').includes(order)) &&
     (!date || (c.date || '').includes(date)) &&
     (!name || (c.name || '').includes(name)) &&
     (!phone || (c.phone || c.phoneNumber || '').includes(phone)) &&


### PR DESCRIPTION
## Summary
- drop the Order ID filter from `search.html` and rename the details field to "バイク機種名"
- adjust `search.js` to match date formatting and remove Order ID filtering

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684719f87114832aaa53edd4bf434734