### PR TITLE
Update detail view past records

### DIFF
--- a/web/add.js
+++ b/web/add.js
@@ -2,6 +2,18 @@ const API = (typeof window !== 'undefined' && window.API_URL) ||
   (typeof process !== 'undefined' && process.env && process.env.API_URL) ||
   window.location.origin;
 
+function toHalfWidth(str) {
+  return str.replace(/[Ａ-Ｚａ-ｚ０-９！-～]/g, s => String.fromCharCode(s.charCodeAt(0) - 0xFEE0));
+}
+
+function sanitizeEmailInput(e) {
+  e.target.value = toHalfWidth(e.target.value);
+}
+
+function sanitizePhoneInput(e) {
+  e.target.value = toHalfWidth(e.target.value).replace(/-/g, '');
+}
+
 async function saveCustomer() {
   const note = document.getElementById('f-history-note').value.trim();
   const today = new Date(Date.now() + 9 * 60 * 60 * 1000).toISOString().split('T')[0];
@@ -10,12 +22,27 @@ async function saveCustomer() {
     history[today] = note;
   }
 
+  sanitizeEmailInput({ target: document.getElementById('f-email') });
+  sanitizePhoneInput({ target: document.getElementById('f-phone') });
+
+  const email = document.getElementById('f-email').value.trim();
+  const phone = document.getElementById('f-phone').value.trim();
+
+  if (email && !/^[^@\s]+@[^@\s]+\.[^@\s]+$/.test(email)) {
+    alert('メールアドレスが不正です');
+    return;
+  }
+  if (phone && !/^[0-9]+$/.test(phone)) {
+    alert('電話番号が不正です（数字のみ）');
+    return;
+  }
+
   const body = {
     name: document.getElementById('f-name').value,
     kana: document.getElementById('f-kana').value,
-    email: document.getElementById('f-email').value,
+    email,
     category: document.getElementById('f-category').value,
-    phoneNumber: document.getElementById('f-phone').value,
+    phoneNumber: phone,
     details: document.getElementById('f-details').value,
     staff: document.getElementById('f-staff').value,
     status: '未済',
@@ -31,3 +58,8 @@ async function saveCustomer() {
 
   window.location.href = 'index.html';
 }
+
+document.addEventListener('DOMContentLoaded', () => {
+  document.getElementById('f-email').addEventListener('input', sanitizeEmailInput);
+  document.getElementById('f-phone').addEventListener('input', sanitizePhoneInput);
+});

--- a/web/app.js
+++ b/web/app.js
@@ -56,7 +56,9 @@ async function loadCustomers(page = 1) {
       <td>${c.phoneNumber || c.phone || ''}</td>
       <td>
         ${c.status || ''}
-        <button class="btn btn-sm btn-outline-secondary ms-2" onclick="toggleStatus('${c.order_id}', '${c.status || ''}')">切替</button>
+        <button class="btn btn-sm btn-outline-secondary ms-2" onclick="toggleStatus('${c.order_id}', '${c.status || ''}')">
+          ${c.status === '未済' ? 'タスクを完了させる' : 'タスクを未済に戻す'}
+        </button>
       </td>
       <td>
         <button class="btn btn-sm btn-primary" onclick="editCustomer('${c.order_id}')">編集</button>

--- a/web/completed.js
+++ b/web/completed.js
@@ -23,7 +23,9 @@ async function loadCompleted() {
       <td>${c.phoneNumber || c.phone || ''}</td>
       <td>
         ${c.status}
-        <button class="btn btn-sm btn-outline-secondary ms-2" onclick="toggleStatus('${c.order_id}', '${c.status || ''}')">切替</button>
+        <button class="btn btn-sm btn-outline-secondary ms-2" onclick="toggleStatus('${c.order_id}', '${c.status || ''}')">
+          ${c.status === '未済' ? 'タスクを完了させる' : 'タスクを未済に戻す'}
+        </button>
       </td>
       <td><a href="detail.html?id=${c.order_id}">詳細</a></td>`;
     tbody.appendChild(tr);

--- a/web/detail.html
+++ b/web/detail.html
@@ -16,7 +16,7 @@
       <h4>過去の記録</h4>
       <table id="past-table" class="table table-striped">
         <thead>
-          <tr><th>日付</th><th>状態</th><th>メモ</th></tr>
+          <tr><th>日時</th><th>タスクステータス</th><th>メモ</th></tr>
         </thead>
         <tbody></tbody>
       </table>

--- a/web/detail.js
+++ b/web/detail.js
@@ -4,6 +4,17 @@ const API = (typeof window !== 'undefined' && window.API_URL) ||
   (typeof process !== 'undefined' && process.env && process.env.API_URL) ||
   window.location.origin;
 
+function formatDateTime(id) {
+  if (!id || id.length < 14) return '';
+  const y = id.slice(0, 4);
+  const m = id.slice(4, 6);
+  const d = id.slice(6, 8);
+  const hh = id.slice(8, 10);
+  const mm = id.slice(10, 12);
+  const ss = id.slice(12, 14);
+  return `${y}/${m}/${d} ${hh}:${mm}:${ss}`;
+}
+
 async function loadDetail() {
   const params = new URLSearchParams(location.search);
   const id = params.get('id');
@@ -73,7 +84,11 @@ async function loadDetail() {
         const last = keys[keys.length - 1];
         if (last) note = r.history[last];
       }
-      tr.innerHTML = `<td>${r.date || ''}</td><td>${r.status || ''}</td><td>${note}</td>`;
+      const dt = formatDateTime(r.order_id);
+      tr.innerHTML = `
+        <td><a href="detail.html?id=${r.order_id}">${dt}</a></td>
+        <td>${r.status || ''}</td>
+        <td>${note}</td>`;
       pastBody.appendChild(tr);
     });
   } catch (e) {

--- a/web/index.html
+++ b/web/index.html
@@ -18,7 +18,6 @@
           class="form-control"
           placeholder="検索..."
         />
-        <button class="btn btn-primary" onclick="loadCustomers()">更新</button>
         <a class="btn btn-success" href="add.html">電話・訪問対応新規フォーム</a>
         <a class="btn btn-outline-secondary" href="search.html">詳細検索</a>
       </div>

--- a/web/search.html
+++ b/web/search.html
@@ -8,54 +8,56 @@
 <body class="p-4">
   <div class="container">
     <h1 class="mb-3">詳細検索</h1>
-    <div class="mb-3">
-      <label class="form-label">日付</label>
-      <input id="s-date" type="date" class="form-control" />
-    </div>
-    <div class="mb-3">
-      <label class="form-label">名前</label>
-      <input id="s-name" class="form-control" />
-    </div>
-    <div class="mb-3">
-      <label class="form-label">電話番号</label>
-      <input id="s-phone" class="form-control" />
-    </div>
-    <div class="mb-3">
-      <label class="form-label">メール</label>
-      <input id="s-email" class="form-control" />
-    </div>
-    <div class="mb-3">
-      <label class="form-label">状態</label>
-      <select id="s-status" class="form-select">
-        <option value="">--</option>
-        <option value="未済">未済</option>
-        <option value="済">済</option>
-      </select>
-    </div>
-    <div class="mb-3">
-      <label class="form-label">種別</label>
-      <select id="s-category" class="form-select">
-        <option value="">--</option>
-        <option value="電話">電話</option>
-        <option value="訪問対応">訪問対応</option>
-        <option value="メール問い合わせ">メール問い合わせ</option>
-        <option value="その他">その他</option>
-      </select>
-    </div>
-    <div class="mb-3">
-      <label class="form-label">バイク機種名</label>
-      <input id="s-details" class="form-control" />
-    </div>
-    <div class="mb-3">
-      <label class="form-label">並び替え</label>
-      <select id="s-sort" class="form-select">
-        <option value="newest">新しい順</option>
-        <option value="oldest">古い順</option>
-      </select>
-    </div>
-    <div class="mb-3">
-      <button class="btn btn-primary" onclick="searchCustomers()">検索</button>
-      <a class="btn btn-secondary" href="index.html">戻る</a>
+    <div id="search-form" class="d-flex flex-wrap gap-2 mb-3">
+      <details>
+        <summary class="btn btn-outline-secondary">日付</summary>
+        <input id="s-date" type="date" class="form-control mt-2" />
+      </details>
+      <details>
+        <summary class="btn btn-outline-secondary">名前</summary>
+        <input id="s-name" class="form-control mt-2" />
+      </details>
+      <details>
+        <summary class="btn btn-outline-secondary">電話番号</summary>
+        <input id="s-phone" class="form-control mt-2" />
+      </details>
+      <details>
+        <summary class="btn btn-outline-secondary">メール</summary>
+        <input id="s-email" class="form-control mt-2" />
+      </details>
+      <details>
+        <summary class="btn btn-outline-secondary">状態</summary>
+        <select id="s-status" class="form-select mt-2">
+          <option value="">--</option>
+          <option value="未済">未済</option>
+          <option value="済">済</option>
+        </select>
+      </details>
+      <details>
+        <summary class="btn btn-outline-secondary">種別</summary>
+        <select id="s-category" class="form-select mt-2">
+          <option value="">--</option>
+          <option value="電話">電話</option>
+          <option value="訪問対応">訪問対応</option>
+          <option value="メール問い合わせ">メール問い合わせ</option>
+          <option value="その他">その他</option>
+        </select>
+      </details>
+      <details>
+        <summary class="btn btn-outline-secondary">バイク機種名</summary>
+        <input id="s-details" class="form-control mt-2" />
+      </details>
+      <details>
+        <summary class="btn btn-outline-secondary">並び替え</summary>
+        <select id="s-sort" class="form-select mt-2">
+          <option value="newest">新しい順</option>
+          <option value="oldest">古い順</option>
+        </select>
+      </details>
+      <div class="align-self-end mt-2">
+        <button class="btn btn-primary me-2" onclick="searchCustomers()">検索</button>
+        <a class="btn btn-secondary" href="index.html">戻る</a>
+      </div>
     </div>
     <table id="result-table" class="table table-striped">
       <thead>


### PR DESCRIPTION
## Summary
- show date and time for past records on detail page
- rename column to "タスクステータス"
- link past record timestamps to each order's detail view

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_684720aeaf44832a8f3106f04d4c8af1