### PR TITLE
Remove sort field from detail search

### DIFF
--- a/web/search.html
+++ b/web/search.html
@@ -47,13 +47,6 @@
         <summary class="btn btn-outline-secondary">バイク機種名</summary>
         <input id="s-details" class="form-control mt-2" />
       </details>
-      <details>
-        <summary class="btn btn-outline-secondary">並び替え</summary>
-        <select id="s-sort" class="form-select mt-2">
-          <option value="newest">新しい順</option>
-          <option value="oldest">古い順</option>
-        </select>
-      </details>
       <div class="align-self-end mt-2">
         <button class="btn btn-primary me-2" onclick="searchCustomers()">検索</button>
         <a class="btn btn-secondary" href="index.html">戻る</a>

--- a/web/search.js
+++ b/web/search.js
@@ -4,11 +4,6 @@ const API = (typeof window !== 'undefined' && window.API_URL) ||
   (typeof process !== 'undefined' && process.env && process.env.API_URL) ||
   window.location.origin;
 
-function getKey(c) {
-  if (c.order_id) return c.order_id.slice(0, 14);
-  if (c.date) return c.date.replace(/\//g, '');
-  return 0;
-}
 
 async function searchCustomers() {
   const dateInput = document.getElementById('s-date').value.trim();
@@ -19,7 +14,6 @@ async function searchCustomers() {
   const status = document.getElementById('s-status').value.trim();
   const category = document.getElementById('s-category').value.trim();
   const details = document.getElementById('s-details').value.trim();
-  const sort = document.getElementById('s-sort').value;
 
   const res = await fetch(API + '/customers');
   const data = await res.json();
@@ -35,15 +29,6 @@ async function searchCustomers() {
     (!details || (c.details || '').includes(details))
   );
 
-  customers.sort((a, b) => {
-    const ka = getKey(a);
-    const kb = getKey(b);
-    if (ka === kb) return 0;
-    if (sort === 'newest') {
-      return ka > kb ? -1 : 1;
-    }
-    return ka < kb ? -1 : 1;
-  });
 
   const tbody = document.querySelector('#result-table tbody');
   tbody.innerHTML = '';


### PR DESCRIPTION
## Summary
- simplify UI by dropping sort options from the detail search screen
- remove client-side sorting logic in search.js

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6847272a7b3c832a83239539fa5e9acb