### PR TITLE
Show pending history snippet

### DIFF
--- a/web/pending.html
+++ b/web/pending.html
@@ -11,7 +11,13 @@
     <h1 class="mb-3">未済一覧</h1>
     <table id="pending-table" class="table table-striped">
       <thead>
-        <tr><th>名前</th><th>電話番号</th><th>ステータス</th><th>詳細</th></tr>
+        <tr>
+          <th>名前</th>
+          <th>電話番号</th>
+          <th>ステータス</th>
+          <th>日付</th>
+          <th>履歴</th>
+        </tr>
       </thead>
       <tbody></tbody>
     </table>

--- a/web/pending.js
+++ b/web/pending.js
@@ -8,6 +8,17 @@ function getKey(c) {
   return 0;
 }
 
+function formatDateTime(id) {
+  if (!id || id.length < 14) return '';
+  const y = id.slice(0, 4);
+  const m = id.slice(4, 6);
+  const d = id.slice(6, 8);
+  const hh = id.slice(8, 10);
+  const mm = id.slice(10, 12);
+  const ss = id.slice(12, 14);
+  return `${y}/${m}/${d} ${hh}:${mm}:${ss}`;
+}
+
 async function loadPending() {
   const res = await fetch(API + '/customers');
   const data = await res.json();
@@ -18,11 +29,20 @@ async function loadPending() {
   tbody.innerHTML = '';
   customers.forEach(c => {
     const tr = document.createElement('tr');
+    let noteSnippet = '';
+    if (c.history) {
+      const keys = Object.keys(c.history).sort();
+      const last = keys[keys.length - 1];
+      if (last) noteSnippet = c.history[last] || '';
+    }
+    if (noteSnippet.length > 50) noteSnippet = noteSnippet.slice(0, 50) + '…';
+    noteSnippet = noteSnippet.replace(/\n/g, '<br>');
     tr.innerHTML = `
       <td><a href="detail.html?id=${c.order_id}">${c.name}</a></td>
       <td>${c.phoneNumber || c.phone || ''}</td>
       <td>${c.status || ''}</td>
-      <td><a href="detail.html?id=${c.order_id}">詳細</a></td>`;
+      <td>${formatDateTime(c.order_id)}</td>
+      <td style="white-space: pre-wrap;">${noteSnippet}</td>`;
     tbody.appendChild(tr);
   });
 }


### PR DESCRIPTION
## Summary
- expand Pending list columns to show date and history
- convert order IDs to readable dates in the pending list
- display the newest history note snippet for each customer

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68472f4360c4832aabf4a2c9b7a04592