### PR TITLE
Enable sortable date columns

### DIFF
--- a/web/all.html
+++ b/web/all.html
@@ -15,7 +15,7 @@
           <th>名前</th>
           <th>電話番号</th>
           <th>ステータス</th>
-          <th>日付</th>
+          <th id="date-header" style="cursor:pointer;">日付</th>
           <th style="width:20%;">履歴</th>
           <th>編集</th>
           <th>削除</th>

--- a/web/all.js
+++ b/web/all.js
@@ -2,6 +2,8 @@ const API = (typeof window !== 'undefined' && window.API_URL) ||
   (typeof process !== 'undefined' && process.env && process.env.API_URL) ||
   window.location.origin;
 
+let sortDescending = true;
+
 function formatDateTime(id) {
   if (!id || id.length < 14) return ''; // 正しく14桁チェック
   const y = id.slice(0, 4);
@@ -23,7 +25,9 @@ async function loadAll() {
   const res = await fetch(API + '/customers');
   const data = await res.json();
   let customers = data.Items || data;
-  customers.sort((a, b) => getKey(a) - getKey(b));
+  customers.sort((a, b) =>
+    sortDescending ? getKey(b) - getKey(a) : getKey(a) - getKey(b)
+  );
 
   const tbody = document.querySelector('#all-table tbody');
   tbody.innerHTML = '';
@@ -71,4 +75,13 @@ async function toggleStatus(id, current) {
   loadAll();
 }
 
-window.addEventListener('DOMContentLoaded', loadAll);
+window.addEventListener('DOMContentLoaded', () => {
+  const header = document.getElementById('date-header');
+  if (header) {
+    header.addEventListener('click', () => {
+      sortDescending = !sortDescending;
+      loadAll();
+    });
+  }
+  loadAll();
+});

--- a/web/app.js
+++ b/web/app.js
@@ -6,6 +6,7 @@ const API = (typeof window !== 'undefined' && window.API_URL) ||
 
 let currentPage = 1;
 const PAGE_SIZE = 10;
+let sortDescending = true;
 
 function formatDateTime(id) {
   if (!id || id.length < 14) return '';
@@ -54,7 +55,9 @@ async function loadCustomers(page = 1) {
   let customers = data.Items || data;
 
   customers = customers.filter(c => (c.status || '') !== '済');
-  customers.sort((a, b) => getKey(a) - getKey(b));
+  customers.sort((a, b) =>
+    sortDescending ? getKey(b) - getKey(a) : getKey(a) - getKey(b)
+  );
 
   const totalPages = Math.max(1, Math.ceil(customers.length / PAGE_SIZE));
   if (currentPage > totalPages) currentPage = totalPages;
@@ -126,5 +129,13 @@ function prevPage() {
 }
 
 // 初期表示
+const dateHeader = document.getElementById('date-header');
+if (dateHeader) {
+  dateHeader.addEventListener('click', () => {
+    sortDescending = !sortDescending;
+    loadCustomers();
+  });
+}
+
 loadDashboard();
 loadCustomers();

--- a/web/completed.html
+++ b/web/completed.html
@@ -11,7 +11,7 @@
     <h1 class="mb-3">完了済み一覧</h1>
     <table id="done-table" class="table table-striped">
       <thead>
-        <tr><th>名前</th><th>電話番号</th><th>状態</th><th>日付</th><th style="width:20%;">履歴</th></tr>
+        <tr><th>名前</th><th>電話番号</th><th>状態</th><th id="date-header" style="cursor:pointer;">日付</th><th style="width:20%;">履歴</th></tr>
       </thead>
       <tbody></tbody>
     </table>

--- a/web/completed.js
+++ b/web/completed.js
@@ -2,6 +2,8 @@ const API = (typeof window !== 'undefined' && window.API_URL) ||
   (typeof process !== 'undefined' && process.env && process.env.API_URL) ||
   window.location.origin;
 
+let sortDescending = true;
+
 function getKey(c) {
   if (c.order_id) return c.order_id.slice(0, 14);
   if (c.date) return c.date.replace(/\//g, '');
@@ -22,7 +24,9 @@ async function loadCompleted() {
   const res = await fetch(API + '/customers');
   const data = await res.json();
   let customers = (data.Items || data).filter(c => (c.status || '') === '済');
-  customers.sort((a, b) => getKey(a) - getKey(b));
+  customers.sort((a, b) =>
+    sortDescending ? getKey(b) - getKey(a) : getKey(a) - getKey(b)
+  );
 
   const tbody = document.querySelector('#done-table tbody');
   tbody.innerHTML = '';
@@ -62,4 +66,13 @@ async function toggleStatus(id, current) {
   loadCompleted();
 }
 
-window.addEventListener('DOMContentLoaded', loadCompleted);
+window.addEventListener('DOMContentLoaded', () => {
+  const header = document.getElementById('date-header');
+  if (header) {
+    header.addEventListener('click', () => {
+      sortDescending = !sortDescending;
+      loadCompleted();
+    });
+  }
+  loadCompleted();
+});

--- a/web/index.html
+++ b/web/index.html
@@ -88,7 +88,7 @@
                 <th>名前</th>
                 <th>電話番号</th>
                 <th>ステータス</th>
-                <th>日付</th>
+                <th id="date-header" style="cursor:pointer;">日付</th>
                 <th style="width:20%;">履歴</th>
                 <th>操作</th>
               </tr>

--- a/web/pending.html
+++ b/web/pending.html
@@ -16,7 +16,7 @@
           <th>名前</th>
           <th>電話番号</th>
           <th>ステータス</th>
-          <th>日付</th>
+          <th id="date-header" style="cursor:pointer;">日付</th>
           <th style="width:20%;">履歴</th>
         </tr>
       </thead>

--- a/web/pending.js
+++ b/web/pending.js
@@ -2,6 +2,8 @@ const API = (typeof window !== 'undefined' && window.API_URL) ||
   (typeof process !== 'undefined' && process.env && process.env.API_URL) ||
   window.location.origin;
 
+let sortDescending = true;
+
 function getKey(c) {
   if (c.order_id) return c.order_id.slice(0, 14);
   if (c.date) return c.date.replace(/\//g, '');
@@ -22,7 +24,9 @@ async function loadPending() {
   const res = await fetch(API + '/customers');
   const data = await res.json();
   let customers = (data.Items || data).filter(c => (c.status || '') === '未済');
-  customers.sort((a, b) => getKey(a) - getKey(b));
+  customers.sort((a, b) =>
+    sortDescending ? getKey(b) - getKey(a) : getKey(a) - getKey(b)
+  );
 
   const tbody = document.querySelector('#pending-table tbody');
   tbody.innerHTML = '';
@@ -52,4 +56,13 @@ async function loadPending() {
   });
 }
 
-window.addEventListener('DOMContentLoaded', loadPending);
+window.addEventListener('DOMContentLoaded', () => {
+  const header = document.getElementById('date-header');
+  if (header) {
+    header.addEventListener('click', () => {
+      sortDescending = !sortDescending;
+      loadPending();
+    });
+  }
+  loadPending();
+});

--- a/web/today.html
+++ b/web/today.html
@@ -11,7 +11,7 @@
     <h1 class="mb-3">本日の問い合わせ</h1>
     <table id="today-table" class="table table-striped">
       <thead>
-        <tr><th>名前</th><th>電話番号</th><th>ステータス</th><th>日付</th><th style="width:20%;">履歴</th></tr>
+        <tr><th>名前</th><th>電話番号</th><th>ステータス</th><th id="date-header" style="cursor:pointer;">日付</th><th style="width:20%;">履歴</th></tr>
       </thead>
       <tbody></tbody>
     </table>

--- a/web/today.js
+++ b/web/today.js
@@ -2,6 +2,8 @@ const API = (typeof window !== 'undefined' && window.API_URL) ||
   (typeof process !== 'undefined' && process.env && process.env.API_URL) ||
   window.location.origin;
 
+let sortDescending = true;
+
 function getKey(c) {
   if (c.order_id) return c.order_id.slice(0, 14);
   if (c.date) return c.date.replace(/\//g, '');
@@ -29,7 +31,9 @@ async function loadToday() {
     if (c.order_id) return c.order_id.slice(0, 8) === todayKey;
     return false;
   });
-  customers.sort((a, b) => getKey(a) - getKey(b));
+  customers.sort((a, b) =>
+    sortDescending ? getKey(b) - getKey(a) : getKey(a) - getKey(b)
+  );
 
   const tbody = document.querySelector('#today-table tbody');
   tbody.innerHTML = '';
@@ -54,4 +58,13 @@ async function loadToday() {
   });
 }
 
-window.addEventListener('DOMContentLoaded', loadToday);
+window.addEventListener('DOMContentLoaded', () => {
+  const header = document.getElementById('date-header');
+  if (header) {
+    header.addEventListener('click', () => {
+      sortDescending = !sortDescending;
+      loadToday();
+    });
+  }
+  loadToday();
+});


### PR DESCRIPTION
## Summary
- make tables sort by date when clicking header
- default sort order shows newest first

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68473a9a0fd8832aaef04a5e8d6b6a7e