### PR TITLE
Add status toggle for today's inquiries

### DIFF
--- a/web/add.html
+++ b/web/add.html
@@ -38,7 +38,7 @@
       </div>
 
       <div class="mb-2">担当: <input id="f-staff" class="form-control" /></div>
-      <div class="mb-2">履歴: <textarea id="f-history-note" class="form-control"></textarea></div>
+      <div class="mb-2">履歴: <textarea id="f-history-note" class="form-control" rows="12"></textarea></div>
 
       <div>
         <button class="btn btn-primary" onclick="saveCustomer()">保存</button>

--- a/web/app.js
+++ b/web/app.js
@@ -38,11 +38,27 @@ async function loadDashboard() {
     if (c.order_id) return c.order_id.slice(0, 8) === todayKey;
     return false;
   }).length;
+  const phoneToday = customers.filter(c => {
+    const isToday = c.date ? c.date === today : c.order_id && c.order_id.slice(0, 8) === todayKey;
+    return isToday && (c.type || c.category) === '電話';
+  }).length;
+  const visitToday = customers.filter(c => {
+    const isToday = c.date ? c.date === today : c.order_id && c.order_id.slice(0, 8) === todayKey;
+    return isToday && (c.type || c.category) === '訪問対応';
+  }).length;
   const unconfirmed = customers.filter(c => (c.status || '') === '未済').length;
   const completed = customers.filter(c => (c.status || '') === '済').length;
 
   document.getElementById('d-total').textContent = total;
   document.getElementById('d-today').textContent = todayCount;
+  const phoneEl = document.getElementById('d-phone-today');
+  if (phoneEl) phoneEl.textContent = phoneToday;
+  const visitEl = document.getElementById('d-visit-today');
+  if (visitEl) visitEl.textContent = visitToday;
+  const mailAutoEl = document.getElementById('d-mail-auto');
+  if (mailAutoEl) mailAutoEl.textContent = 0;
+  const callLogEl = document.getElementById('d-call-log');
+  if (callLogEl) callLogEl.textContent = 0;
   document.getElementById('d-unconfirmed').textContent = unconfirmed;
   const compEl = document.getElementById('d-completed');
   if (compEl) compEl.textContent = completed;

--- a/web/edit.html
+++ b/web/edit.html
@@ -31,7 +31,7 @@
         </select>
       </div>
       <div class="mb-2">担当: <input id="f-staff" class="form-control" /></div>
-      <div class="mb-2">履歴: <textarea id="f-history-note" class="form-control"></textarea></div>
+      <div class="mb-2">履歴: <textarea id="f-history-note" class="form-control" rows="12"></textarea></div>
       <div id="history-view" class="mb-2"></div>
       <div>
         <button class="btn btn-primary" onclick="saveCustomer()">保存</button>

--- a/web/index.html
+++ b/web/index.html
@@ -23,7 +23,7 @@
 
     <div class="row mb-3">
       <!-- Dashboard Area -->
-      <div id="dashboard" class="col-md-6 mb-3 mb-md-0" style="height:600px; overflow:auto;">
+      <div id="dashboard" class="col-md-6 mb-3 mb-md-0" style="height:600px; overflow:auto; resize: horizontal;">
         <div id="dashboard-metrics" class="row row-cols-2 g-2 mb-3">
           <div class="col">
             <a href="all.html" class="text-decoration-none">
@@ -46,10 +46,42 @@
             </a>
           </div>
           <div class="col">
+            <div class="card text-center">
+              <div class="card-body">
+                <div>本日の電話対応一覧</div>
+                <div id="d-phone-today" class="fs-3">0</div>
+              </div>
+            </div>
+          </div>
+          <div class="col">
+            <div class="card text-center">
+              <div class="card-body">
+                <div>訪問対応一覧</div>
+                <div id="d-visit-today" class="fs-3">0</div>
+              </div>
+            </div>
+          </div>
+          <div class="col">
+            <div class="card text-center">
+              <div class="card-body">
+                <div>メール自動追加</div>
+                <div id="d-mail-auto" class="fs-3">0</div>
+              </div>
+            </div>
+          </div>
+          <div class="col">
+            <div class="card text-center">
+              <div class="card-body">
+                <div>受電履歴</div>
+                <div id="d-call-log" class="fs-3">0</div>
+              </div>
+            </div>
+          </div>
+          <div class="col">
             <a href="pending.html" class="text-decoration-none">
               <div class="card text-center">
                 <div class="card-body">
-                  <div>未済</div>
+                  <div>今日時点までの未済</div>
                   <div id="d-unconfirmed" class="fs-3">0</div>
                 </div>
               </div>
@@ -71,7 +103,7 @@
       </div>
 
       <!-- Mail Area -->
-      <div id="mail" class="col-md-6" style="height:600px;">
+      <div id="mail" class="col-md-6" style="height:600px; resize: horizontal; overflow:auto;">
         <div class="d-flex flex-column h-100">
           <div class="border flex-fill p-3 mb-2">メール</div>
           <div class="border flex-fill p-3">受電履歴（アイブリー）</div>

--- a/web/today.js
+++ b/web/today.js
@@ -51,11 +51,26 @@ async function loadToday() {
     tr.innerHTML = `
       <td><a href="detail.html?id=${c.order_id}">${c.name}</a></td>
       <td>${c.phoneNumber || c.phone || ''}</td>
-      <td>${c.status || ''}</td>
+      <td>
+        ${c.status || ''}
+        <button class="btn btn-sm btn-outline-secondary ms-2" onclick="toggleStatus('${c.order_id}', '${c.status || ''}')">
+          ${c.status === '未済' ? 'タスクを完了させる' : 'タスクを未済に戻す'}
+        </button>
+      </td>
       <td>${formatDateTime(c.order_id)}</td>
       <td style="width:20%; white-space: pre-wrap;">${snippet}</td>`;
     tbody.appendChild(tr);
   });
+}
+
+async function toggleStatus(id, current) {
+  const newStatus = current === '済' ? '未済' : '済';
+  await fetch(API + '/customers/' + id, {
+    method: 'PUT',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ status: newStatus })
+  });
+  loadToday();
 }
 
 window.addEventListener('DOMContentLoaded', () => {


### PR DESCRIPTION
## Summary
- allow toggling task status on the today page
- show history input as 12 lines in the add and edit forms
- show placeholders for today's phone/visit/email/call history counts on the dashboard
- rename incomplete metric and make dashboard/mail sections resizable

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68473ce6f374832a9b7e852602403bd2