### PR TITLE
Add date grouping and unify time format

### DIFF
--- a/web/all.js
+++ b/web/all.js
@@ -5,14 +5,21 @@ const API = (typeof window !== 'undefined' && window.API_URL) ||
 let sortDescending = true;
 
 function formatDateTime(id) {
-  if (!id || id.length < 14) return ''; // 正しく14桁チェック
+  if (!id || id.length < 12) return '';
   const y = id.slice(0, 4);
   const m = id.slice(4, 6);
   const d = id.slice(6, 8);
   const hh = id.slice(8, 10);
   const mm = id.slice(10, 12);
-  const ss = id.slice(12, 14);
-  return `${y}/${m}/${d} ${hh}:${mm}:${ss}`;
+  return `${y}/${m}/${d} ${hh}時${mm}分`;
+}
+
+function getDateStr(item) {
+  let key = '';
+  if (item.order_id) key = item.order_id.slice(0, 8);
+  else if (item.date) key = item.date.replace(/\//g, '').slice(0, 8);
+  if (!key) return '';
+  return `${key.slice(0, 4)}/${key.slice(4, 6)}/${key.slice(6, 8)}`;
 }
 
 function getKey(c) {
@@ -31,7 +38,22 @@ async function loadAll() {
 
   const tbody = document.querySelector('#all-table tbody');
   tbody.innerHTML = '';
+  const colspan = document.querySelector('#all-table thead tr').children.length;
+  let lastDate = '';
+
   customers.forEach(c => {
+    const dateStr = getDateStr(c);
+    if (dateStr && dateStr !== lastDate) {
+      const gr = document.createElement('tr');
+      const td = document.createElement('td');
+      td.colSpan = colspan;
+      td.className = 'table-secondary fw-bold';
+      td.textContent = dateStr;
+      gr.appendChild(td);
+      tbody.appendChild(gr);
+      lastDate = dateStr;
+    }
+
     const tr = document.createElement('tr');
     let noteSnippet = '';
     if (c.history) {

--- a/web/app.js
+++ b/web/app.js
@@ -9,14 +9,21 @@ const PAGE_SIZE = 10;
 let sortDescending = true;
 
 function formatDateTime(id) {
-  if (!id || id.length < 14) return '';
+  if (!id || id.length < 12) return '';
   const y = id.slice(0, 4);
   const m = id.slice(4, 6);
   const d = id.slice(6, 8);
   const hh = id.slice(8, 10);
   const mm = id.slice(10, 12);
-  const ss = id.slice(12, 14);
-  return `${y}/${m}/${d} ${hh}:${mm}:${ss}`;
+  return `${y}/${m}/${d} ${hh}時${mm}分`;
+}
+
+function getDateStr(item) {
+  let key = '';
+  if (item.order_id) key = item.order_id.slice(0, 8);
+  else if (item.date) key = item.date.replace(/\//g, '').slice(0, 8);
+  if (!key) return '';
+  return `${key.slice(0, 4)}/${key.slice(4, 6)}/${key.slice(6, 8)}`;
 }
 
 function getKey(c) {
@@ -83,7 +90,23 @@ async function loadCustomers(page = 1) {
   tbody.innerHTML = '';
 
   const start = (currentPage - 1) * PAGE_SIZE;
-  customers.slice(start, start + PAGE_SIZE).forEach(c => {
+  const slice = customers.slice(start, start + PAGE_SIZE);
+  const colspan = document.querySelector('#customer-table thead tr').children.length;
+  let lastDate = '';
+
+  slice.forEach(c => {
+    const dateStr = getDateStr(c);
+    if (dateStr && dateStr !== lastDate) {
+      const gr = document.createElement('tr');
+      const td = document.createElement('td');
+      td.colSpan = colspan;
+      td.className = 'table-secondary fw-bold';
+      td.textContent = dateStr;
+      gr.appendChild(td);
+      tbody.appendChild(gr);
+      lastDate = dateStr;
+    }
+
     const tr = document.createElement('tr');
     let noteSnippet = '';
     if (c.history) {

--- a/web/completed.js
+++ b/web/completed.js
@@ -17,7 +17,15 @@ function formatDateTime(id) {
   const d = id.slice(6, 8);
   const hh = id.slice(8, 10);
   const mm = id.slice(10, 12);
-  return `${y}/${m}/${d} ${hh}:${mm}`;
+  return `${y}/${m}/${d} ${hh}時${mm}分`;
+}
+
+function getDateStr(item) {
+  let key = '';
+  if (item.order_id) key = item.order_id.slice(0, 8);
+  else if (item.date) key = item.date.replace(/\//g, '').slice(0, 8);
+  if (!key) return '';
+  return `${key.slice(0, 4)}/${key.slice(4, 6)}/${key.slice(6, 8)}`;
 }
 
 async function loadCompleted() {
@@ -30,7 +38,22 @@ async function loadCompleted() {
 
   const tbody = document.querySelector('#done-table tbody');
   tbody.innerHTML = '';
+  const colspan = document.querySelector('#done-table thead tr').children.length;
+  let lastDate = '';
+
   customers.forEach(c => {
+    const dateStr = getDateStr(c);
+    if (dateStr && dateStr !== lastDate) {
+      const gr = document.createElement('tr');
+      const td = document.createElement('td');
+      td.colSpan = colspan;
+      td.className = 'table-secondary fw-bold';
+      td.textContent = dateStr;
+      gr.appendChild(td);
+      tbody.appendChild(gr);
+      lastDate = dateStr;
+    }
+
     const tr = document.createElement('tr');
     let note = '';
     if (c.history) {

--- a/web/detail.js
+++ b/web/detail.js
@@ -11,7 +11,7 @@ function formatDateTime(id) {
   const d = id.slice(6, 8);
   const hh = id.slice(8, 10);
   const mm = id.slice(10, 12);
-  return `${y}/${m}/${d} ${hh}:${mm}`;
+  return `${y}/${m}/${d} ${hh}時${mm}分`;
 }
 
 function getKey(c) {

--- a/web/pending.js
+++ b/web/pending.js
@@ -17,7 +17,15 @@ function formatDateTime(id) {
   const d = id.slice(6, 8);
   const hh = id.slice(8, 10);
   const mm = id.slice(10, 12);
-  return `${y}/${m}/${d} ${hh}:${mm}`;
+  return `${y}/${m}/${d} ${hh}時${mm}分`;
+}
+
+function getDateStr(item) {
+  let key = '';
+  if (item.order_id) key = item.order_id.slice(0, 8);
+  else if (item.date) key = item.date.replace(/\//g, '').slice(0, 8);
+  if (!key) return '';
+  return `${key.slice(0, 4)}/${key.slice(4, 6)}/${key.slice(6, 8)}`;
 }
 
 async function loadPending() {
@@ -30,8 +38,22 @@ async function loadPending() {
 
   const tbody = document.querySelector('#pending-table tbody');
   tbody.innerHTML = '';
+  const colspan = document.querySelector('#pending-table thead tr').children.length;
+  let lastDate = '';
 
   customers.forEach(c => {
+    const dateStr = getDateStr(c);
+    if (dateStr && dateStr !== lastDate) {
+      const gr = document.createElement('tr');
+      const td = document.createElement('td');
+      td.colSpan = colspan;
+      td.className = 'table-secondary fw-bold';
+      td.textContent = dateStr;
+      gr.appendChild(td);
+      tbody.appendChild(gr);
+      lastDate = dateStr;
+    }
+
     const tr = document.createElement('tr');
 
     let noteSnippet = '';

--- a/web/today.js
+++ b/web/today.js
@@ -17,7 +17,15 @@ function formatDateTime(id) {
   const d = id.slice(6, 8);
   const hh = id.slice(8, 10);
   const mm = id.slice(10, 12);
-  return `${y}/${m}/${d} ${hh}:${mm}`;
+  return `${y}/${m}/${d} ${hh}時${mm}分`;
+}
+
+function getDateStr(item) {
+  let key = '';
+  if (item.order_id) key = item.order_id.slice(0, 8);
+  else if (item.date) key = item.date.replace(/\//g, '').slice(0, 8);
+  if (!key) return '';
+  return `${key.slice(0, 4)}/${key.slice(4, 6)}/${key.slice(6, 8)}`;
 }
 
 async function loadToday() {
@@ -37,7 +45,22 @@ async function loadToday() {
 
   const tbody = document.querySelector('#today-table tbody');
   tbody.innerHTML = '';
+  const colspan = document.querySelector('#today-table thead tr').children.length;
+  let lastDate = '';
+
   customers.forEach(c => {
+    const dateStr = getDateStr(c);
+    if (dateStr && dateStr !== lastDate) {
+      const gr = document.createElement('tr');
+      const td = document.createElement('td');
+      td.colSpan = colspan;
+      td.className = 'table-secondary fw-bold';
+      td.textContent = dateStr;
+      gr.appendChild(td);
+      tbody.appendChild(gr);
+      lastDate = dateStr;
+    }
+
     const tr = document.createElement('tr');
     let note = '';
     if (c.history) {


### PR DESCRIPTION
## Summary
- unify time display across client scripts using `YYYY/MM/DD HH時MM分`
- visually group table rows by date for all listing pages

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6847425f9b30832a83163294b426c973