### PR TITLE
Add back navigation using history

### DIFF
--- a/web/add.html
+++ b/web/add.html
@@ -42,13 +42,15 @@
 
       <div>
         <button class="btn btn-primary" onclick="saveCustomer()">保存</button>
-        <a class="btn btn-secondary" href="index.html">キャンセル</a>
+        <a class="btn btn-secondary" href="#" onclick="goBack(event)">キャンセル</a>
       </div>
     </div>
   </div>
+  <div id="breadcrumb" class="text-muted small mb-2"></div>
   <footer class="text-center mt-4">
     <small style="color:#7ac142;">©2025 JIMUSURU All rights reserved.</small>
   </footer>
   <script src="add.js"></script>
+  <script src="nav.js"></script>
 </body>
 </html>

--- a/web/all.html
+++ b/web/all.html
@@ -23,11 +23,13 @@
       </thead>
       <tbody></tbody>
     </table>
-    <a href="index.html" class="btn btn-secondary">戻る</a>
+    <div id="breadcrumb" class="text-muted small mb-2"></div>
+    <a href="#" class="btn btn-secondary" onclick="goBack(event)">戻る</a>
   </div>
   <footer class="text-center mt-4">
     <small style="color:#7ac142;">©2025 JIMUSURU All rights reserved.</small>
   </footer>
   <script src="all.js"></script>
+  <script src="nav.js"></script>
 </body>
 </html>

--- a/web/completed.html
+++ b/web/completed.html
@@ -15,11 +15,13 @@
       </thead>
       <tbody></tbody>
     </table>
-    <a href="index.html" class="btn btn-secondary">戻る</a>
+    <div id="breadcrumb" class="text-muted small mb-2"></div>
+    <a href="#" class="btn btn-secondary" onclick="goBack(event)">戻る</a>
   </div>
   <footer class="text-center mt-4">
     <small style="color:#7ac142;">©2025 JIMUSURU All rights reserved.</small>
   </footer>
   <script src="completed.js"></script>
+  <script src="nav.js"></script>
 </body>
 </html>

--- a/web/debug.html
+++ b/web/debug.html
@@ -10,11 +10,13 @@
   <div class="container">
     <h1 class="mb-3">Debug: All Customers</h1>
     <pre id="data">Loading...</pre>
-    <a href="index.html" class="btn btn-secondary mt-3">Back</a>
+    <div id="breadcrumb" class="text-muted small mb-2"></div>
+    <a href="#" class="btn btn-secondary mt-3" onclick="goBack(event)">Back</a>
   </div>
   <footer class="text-center mt-4">
     <small style="color:#7ac142;">©2025 JIMUSURU All rights reserved.</small>
   </footer>
   <script src="debug.js"></script>
+  <script src="nav.js"></script>
 </body>
 </html>

--- a/web/detail.html
+++ b/web/detail.html
@@ -22,9 +22,10 @@
         <tbody></tbody>
       </table>
     </div>
+    <div id="breadcrumb" class="text-muted small mb-2"></div>
     <div class="mb-3">
       <a id="edit-link" class="btn btn-primary me-2" href="#">編集</a>
-      <a href="index.html" class="btn btn-secondary">戻る</a>
+      <a href="#" class="btn btn-secondary" onclick="goBack(event)">戻る</a>
     </div>
   </div>
 
@@ -33,5 +34,6 @@
   </footer>
 
   <script src="detail.js"></script>
+  <script src="nav.js"></script>
 </body>
 </html>

--- a/web/edit.html
+++ b/web/edit.html
@@ -35,14 +35,16 @@
       <div id="history-view" class="mb-2"></div>
       <div>
         <button class="btn btn-primary" onclick="saveCustomer()">保存</button>
-        <a class="btn btn-secondary" href="all.html">キャンセル</a>
+        <a class="btn btn-secondary" href="#" onclick="goBack(event)">キャンセル</a>
       </div>
-    </div>
   </div>
+  </div>
+  <div id="breadcrumb" class="text-muted small mb-2"></div>
     <footer class="text-center mt-4">
       <small style="color:#7ac142;">©2025 JIMUSURU All rights reserved.</small>
     </footer>
 
     <script src="edit.js"></script>
+    <script src="nav.js"></script>
   </body>
 </html>

--- a/web/nav.js
+++ b/web/nav.js
@@ -1,0 +1,22 @@
+function goBack(event) {
+  if (event) event.preventDefault();
+  if (document.referrer && document.referrer.startsWith(window.location.origin)) {
+    window.history.back();
+  } else {
+    window.location.href = 'index.html';
+  }
+}
+
+function showBreadcrumb() {
+  const el = document.getElementById('breadcrumb');
+  if (!el) return;
+  let prev = '';
+  if (document.referrer && document.referrer.startsWith(window.location.origin)) {
+    const url = new URL(document.referrer);
+    prev = decodeURIComponent(url.pathname.split('/').pop());
+  }
+  const current = decodeURIComponent(window.location.pathname.split('/').pop());
+  el.textContent = prev ? `${prev} > ${current}` : current;
+}
+
+document.addEventListener('DOMContentLoaded', showBreadcrumb);

--- a/web/pending.html
+++ b/web/pending.html
@@ -22,8 +22,8 @@
       </thead>
       <tbody></tbody>
     </table>
-
-    <a href="index.html" class="btn btn-secondary">戻る</a>
+    <div id="breadcrumb" class="text-muted small mb-2"></div>
+    <a href="#" class="btn btn-secondary" onclick="goBack(event)">戻る</a>
   </div>
 
   <footer class="text-center mt-4">
@@ -31,5 +31,6 @@
   </footer>
 
   <script src="pending.js"></script>
+  <script src="nav.js"></script>
 </body>
 </html>

--- a/web/search.html
+++ b/web/search.html
@@ -50,9 +50,10 @@
       </details>
       <div class="align-self-end mt-2">
         <button class="btn btn-primary me-2" onclick="searchCustomers()">検索</button>
-        <a class="btn btn-secondary" href="index.html">戻る</a>
+        <a class="btn btn-secondary" href="#" onclick="goBack(event)">戻る</a>
       </div>
     </div>
+    <div id="breadcrumb" class="text-muted small mb-2"></div>
     <table id="result-table" class="table table-striped">
       <thead>
         <tr><th>名前</th><th>メール</th><th>種別</th><th>状態</th><th>詳細</th></tr>
@@ -64,5 +65,6 @@
     <small style="color:#7ac142;">©2025 JIMUSURU All rights reserved.</small>
   </footer>
   <script src="search.js"></script>
+  <script src="nav.js"></script>
 </body>
 </html>

--- a/web/today.html
+++ b/web/today.html
@@ -15,11 +15,13 @@
       </thead>
       <tbody></tbody>
     </table>
-    <a href="index.html" class="btn btn-secondary">戻る</a>
+    <div id="breadcrumb" class="text-muted small mb-2"></div>
+    <a href="#" class="btn btn-secondary" onclick="goBack(event)">戻る</a>
   </div>
   <footer class="text-center mt-4">
     <small style="color:#7ac142;">©2025 JIMUSURU All rights reserved.</small>
   </footer>
   <script src="today.js"></script>
+  <script src="nav.js"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- improve back button behavior by leveraging browser history
- show simple breadcrumb of the previous page
- update pages to use new `nav.js` helper

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6847439e053c832ab2178ca318eab259