### PR TITLE
Add pagination support across all listing pages

### DIFF
--- a/web/all.html
+++ b/web/all.html
@@ -23,6 +23,13 @@
       </thead>
       <tbody></tbody>
     </table>
+    <div class="row mb-3">
+      <div class="col-12 d-flex justify-content-between align-items-center">
+        <button id="prev-btn" class="btn btn-outline-primary btn-sm" onclick="prevPage()">前へ</button>
+        <span id="page-info">1 / 1</span>
+        <button id="next-btn" class="btn btn-outline-primary btn-sm" onclick="nextPage()">次へ</button>
+      </div>
+    </div>
     <div id="breadcrumb" class="text-muted small mb-2"></div>
     <a href="#" class="btn btn-secondary" onclick="goBack(event)">戻る</a>
   </div>

--- a/web/app.js
+++ b/web/app.js
@@ -5,7 +5,7 @@ const API = (typeof window !== 'undefined' && window.API_URL) ||
   window.location.origin;
 
 let currentPage = 1;
-const PAGE_SIZE = 10;
+const PAGE_SIZE = 20;
 let sortDescending = true;
 
 function formatDateTime(id) {

--- a/web/completed.html
+++ b/web/completed.html
@@ -15,6 +15,13 @@
       </thead>
       <tbody></tbody>
     </table>
+    <div class="row mb-3">
+      <div class="col-12 d-flex justify-content-between align-items-center">
+        <button id="prev-btn" class="btn btn-outline-primary btn-sm" onclick="prevPage()">前へ</button>
+        <span id="page-info">1 / 1</span>
+        <button id="next-btn" class="btn btn-outline-primary btn-sm" onclick="nextPage()">次へ</button>
+      </div>
+    </div>
     <div id="breadcrumb" class="text-muted small mb-2"></div>
     <a href="#" class="btn btn-secondary" onclick="goBack(event)">戻る</a>
   </div>

--- a/web/completed.js
+++ b/web/completed.js
@@ -3,6 +3,8 @@ const API = (typeof window !== 'undefined' && window.API_URL) ||
   window.location.origin;
 
 let sortDescending = true;
+let currentPage = 1;
+const PAGE_SIZE = 20;
 
 function getKey(c) {
   if (c.order_id) return c.order_id.slice(0, 14);
@@ -28,7 +30,8 @@ function getDateStr(item) {
   return `${key.slice(0, 4)}/${key.slice(4, 6)}/${key.slice(6, 8)}`;
 }
 
-async function loadCompleted() {
+async function loadCompleted(page = 1) {
+  currentPage = page;
   const res = await fetch(API + '/customers');
   const data = await res.json();
   let customers = (data.Items || data).filter(c => (c.status || '') === '済');
@@ -36,12 +39,18 @@ async function loadCompleted() {
     sortDescending ? getKey(b) - getKey(a) : getKey(a) - getKey(b)
   );
 
+  const totalPages = Math.max(1, Math.ceil(customers.length / PAGE_SIZE));
+  if (currentPage > totalPages) currentPage = totalPages;
+  if (currentPage < 1) currentPage = 1;
+
   const tbody = document.querySelector('#done-table tbody');
   tbody.innerHTML = '';
+  const start = (currentPage - 1) * PAGE_SIZE;
+  const slice = customers.slice(start, start + PAGE_SIZE);
   const colspan = document.querySelector('#done-table thead tr').children.length;
   let lastDate = '';
 
-  customers.forEach(c => {
+  slice.forEach(c => {
     const dateStr = getDateStr(c);
     if (dateStr && dateStr !== lastDate) {
       const gr = document.createElement('tr');
@@ -77,6 +86,21 @@ async function loadCompleted() {
       <td style="width:20%; white-space: pre-wrap;">${snippet}</td>`;
     tbody.appendChild(tr);
   });
+
+  const info = document.getElementById('page-info');
+  if (info) info.textContent = `${currentPage} / ${totalPages}`;
+  const prev = document.getElementById('prev-btn');
+  const next = document.getElementById('next-btn');
+  if (prev) prev.disabled = currentPage === 1;
+  if (next) next.disabled = currentPage === totalPages || customers.length === 0;
+}
+
+function nextPage() {
+  loadCompleted(currentPage + 1);
+}
+
+function prevPage() {
+  loadCompleted(currentPage - 1);
 }
 
 async function toggleStatus(id, current) {

--- a/web/pending.html
+++ b/web/pending.html
@@ -22,6 +22,13 @@
       </thead>
       <tbody></tbody>
     </table>
+    <div class="row mb-3">
+      <div class="col-12 d-flex justify-content-between align-items-center">
+        <button id="prev-btn" class="btn btn-outline-primary btn-sm" onclick="prevPage()">前へ</button>
+        <span id="page-info">1 / 1</span>
+        <button id="next-btn" class="btn btn-outline-primary btn-sm" onclick="nextPage()">次へ</button>
+      </div>
+    </div>
     <div id="breadcrumb" class="text-muted small mb-2"></div>
     <a href="#" class="btn btn-secondary" onclick="goBack(event)">戻る</a>
   </div>

--- a/web/search.html
+++ b/web/search.html
@@ -60,6 +60,13 @@
       </thead>
       <tbody></tbody>
     </table>
+    <div class="row mb-3">
+      <div class="col-12 d-flex justify-content-between align-items-center">
+        <button id="prev-btn" class="btn btn-outline-primary btn-sm" onclick="prevPage()">前へ</button>
+        <span id="page-info">1 / 1</span>
+        <button id="next-btn" class="btn btn-outline-primary btn-sm" onclick="nextPage()">次へ</button>
+      </div>
+    </div>
   </div>
   <footer class="text-center mt-4">
     <small style="color:#7ac142;">©2025 JIMUSURU All rights reserved.</small>

--- a/web/search.js
+++ b/web/search.js
@@ -4,35 +4,48 @@ const API = (typeof window !== 'undefined' && window.API_URL) ||
   (typeof process !== 'undefined' && process.env && process.env.API_URL) ||
   window.location.origin;
 
+let currentPage = 1;
+const PAGE_SIZE = 20;
+let searchResults = [];
 
-async function searchCustomers() {
-  const dateInput = document.getElementById('s-date').value.trim();
-  const date = dateInput ? dateInput.replace(/-/g, '/') : '';
-  const name = document.getElementById('s-name').value.trim();
-  const phone = document.getElementById('s-phone').value.trim();
-  const email = document.getElementById('s-email').value.trim();
-  const status = document.getElementById('s-status').value.trim();
-  const category = document.getElementById('s-category').value.trim();
-  const details = document.getElementById('s-details').value.trim();
+async function searchCustomers(page = 1) {
+  if (page === 1) {
+    const dateInput = document.getElementById('s-date').value.trim();
+    const date = dateInput ? dateInput.replace(/-/g, '/') : '';
+    const name = document.getElementById('s-name').value.trim();
+    const phone = document.getElementById('s-phone').value.trim();
+    const email = document.getElementById('s-email').value.trim();
+    const status = document.getElementById('s-status').value.trim();
+    const category = document.getElementById('s-category').value.trim();
+    const details = document.getElementById('s-details').value.trim();
 
-  const res = await fetch(API + '/customers');
-  const data = await res.json();
-  let customers = data.Items || data;
+    const res = await fetch(API + '/customers');
+    const data = await res.json();
+    let customers = data.Items || data;
 
-  customers = customers.filter(c =>
-    (!date || (c.date || '').includes(date)) &&
-    (!name || (c.name || '').includes(name)) &&
-    (!phone || (c.phone || c.phoneNumber || '').includes(phone)) &&
-    (!email || (c.email || '').includes(email)) &&
-    (!status || (c.status || '') === status) &&
-    (!category || (c.category || '') === category) &&
-    (!details || (c.details || '').includes(details))
-  );
+    customers = customers.filter(c =>
+      (!date || (c.date || '').includes(date)) &&
+      (!name || (c.name || '').includes(name)) &&
+      (!phone || (c.phone || c.phoneNumber || '').includes(phone)) &&
+      (!email || (c.email || '').includes(email)) &&
+      (!status || (c.status || '') === status) &&
+      (!category || (c.category || '') === category) &&
+      (!details || (c.details || '').includes(details))
+    );
 
+    searchResults = customers;
+  }
+
+  currentPage = page;
+  const totalPages = Math.max(1, Math.ceil(searchResults.length / PAGE_SIZE));
+  if (currentPage > totalPages) currentPage = totalPages;
+  if (currentPage < 1) currentPage = 1;
 
   const tbody = document.querySelector('#result-table tbody');
   tbody.innerHTML = '';
-  customers.forEach(c => {
+  const start = (currentPage - 1) * PAGE_SIZE;
+  const slice = searchResults.slice(start, start + PAGE_SIZE);
+  slice.forEach(c => {
     const tr = document.createElement('tr');
     tr.innerHTML = `
       <td><a href="detail.html?id=${c.order_id}">${c.name}</a></td>
@@ -42,6 +55,21 @@ async function searchCustomers() {
       <td><a href="detail.html?id=${c.order_id}">詳細</a></td>`;
     tbody.appendChild(tr);
   });
+
+  const info = document.getElementById('page-info');
+  if (info) info.textContent = `${currentPage} / ${totalPages}`;
+  const prev = document.getElementById('prev-btn');
+  const next = document.getElementById('next-btn');
+  if (prev) prev.disabled = currentPage === 1;
+  if (next) next.disabled = currentPage === totalPages || searchResults.length === 0;
 }
 
-document.addEventListener('DOMContentLoaded', searchCustomers);
+function nextPage() {
+  searchCustomers(currentPage + 1);
+}
+
+function prevPage() {
+  searchCustomers(currentPage - 1);
+}
+
+document.addEventListener('DOMContentLoaded', () => searchCustomers());

--- a/web/today.html
+++ b/web/today.html
@@ -15,6 +15,13 @@
       </thead>
       <tbody></tbody>
     </table>
+    <div class="row mb-3">
+      <div class="col-12 d-flex justify-content-between align-items-center">
+        <button id="prev-btn" class="btn btn-outline-primary btn-sm" onclick="prevPage()">前へ</button>
+        <span id="page-info">1 / 1</span>
+        <button id="next-btn" class="btn btn-outline-primary btn-sm" onclick="nextPage()">次へ</button>
+      </div>
+    </div>
     <div id="breadcrumb" class="text-muted small mb-2"></div>
     <a href="#" class="btn btn-secondary" onclick="goBack(event)">戻る</a>
   </div>

--- a/web/today.js
+++ b/web/today.js
@@ -3,6 +3,8 @@ const API = (typeof window !== 'undefined' && window.API_URL) ||
   window.location.origin;
 
 let sortDescending = true;
+let currentPage = 1;
+const PAGE_SIZE = 20;
 
 function getKey(c) {
   if (c.order_id) return c.order_id.slice(0, 14);
@@ -28,7 +30,8 @@ function getDateStr(item) {
   return `${key.slice(0, 4)}/${key.slice(4, 6)}/${key.slice(6, 8)}`;
 }
 
-async function loadToday() {
+async function loadToday(page = 1) {
+  currentPage = page;
   const res = await fetch(API + '/customers');
   const data = await res.json();
   let customers = data.Items || data;
@@ -43,12 +46,18 @@ async function loadToday() {
     sortDescending ? getKey(b) - getKey(a) : getKey(a) - getKey(b)
   );
 
+  const totalPages = Math.max(1, Math.ceil(customers.length / PAGE_SIZE));
+  if (currentPage > totalPages) currentPage = totalPages;
+  if (currentPage < 1) currentPage = 1;
+
   const tbody = document.querySelector('#today-table tbody');
   tbody.innerHTML = '';
+  const start = (currentPage - 1) * PAGE_SIZE;
+  const slice = customers.slice(start, start + PAGE_SIZE);
   const colspan = document.querySelector('#today-table thead tr').children.length;
   let lastDate = '';
 
-  customers.forEach(c => {
+  slice.forEach(c => {
     const dateStr = getDateStr(c);
     if (dateStr && dateStr !== lastDate) {
       const gr = document.createElement('tr');
@@ -84,6 +93,21 @@ async function loadToday() {
       <td style="width:20%; white-space: pre-wrap;">${snippet}</td>`;
     tbody.appendChild(tr);
   });
+
+  const info = document.getElementById('page-info');
+  if (info) info.textContent = `${currentPage} / ${totalPages}`;
+  const prev = document.getElementById('prev-btn');
+  const next = document.getElementById('next-btn');
+  if (prev) prev.disabled = currentPage === 1;
+  if (next) next.disabled = currentPage === totalPages || customers.length === 0;
+}
+
+function nextPage() {
+  loadToday(currentPage + 1);
+}
+
+function prevPage() {
+  loadToday(currentPage - 1);
 }
 
 async function toggleStatus(id, current) {


### PR DESCRIPTION
## Summary
- paginate results when more than 20 entries are available
- apply pagination UI to all listing pages

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684745495a78832aa861a243d93e0059