### PR TITLE
Add quick search to inquiry pages

### DIFF
--- a/web/all.html
+++ b/web/all.html
@@ -9,6 +9,9 @@
 <body class="p-4">
   <div class="container">
     <h1 class="mb-3">全問い合わせ一覧</h1>
+    <div class="mb-3">
+      <input id="quick-search" class="form-control" placeholder="名前や電話番号、メールアドレスの一部をご入力してください。" />
+    </div>
     <table id="all-table" class="table table-striped">
       <thead>
         <tr>

--- a/web/all.js
+++ b/web/all.js
@@ -35,6 +35,15 @@ async function loadAll(page = 1) {
   const res = await fetch(API + '/customers');
   const data = await res.json();
   let customers = data.Items || data;
+  const qEl = document.getElementById('quick-search');
+  const keyword = qEl ? qEl.value.trim() : '';
+  if (keyword) {
+    customers = customers.filter(c =>
+      (c.name || '').includes(keyword) ||
+      (c.phoneNumber || c.phone || '').includes(keyword) ||
+      (c.email || '').includes(keyword)
+    );
+  }
   customers.sort((a, b) =>
     sortDescending ? getKey(b) - getKey(a) : getKey(a) - getKey(b)
   );
@@ -129,5 +138,7 @@ window.addEventListener('DOMContentLoaded', () => {
       loadAll();
     });
   }
+  const qEl = document.getElementById('quick-search');
+  if (qEl) qEl.addEventListener('input', () => loadAll(1));
   loadAll();
 });

--- a/web/today.html
+++ b/web/today.html
@@ -9,6 +9,9 @@
 <body class="p-4">
   <div class="container">
     <h1 class="mb-3">本日の問い合わせ</h1>
+    <div class="mb-3">
+      <input id="quick-search" class="form-control" placeholder="名前や電話番号、メールアドレスの一部をご入力してください。" />
+    </div>
     <table id="today-table" class="table table-striped">
       <thead>
         <tr><th>名前</th><th>電話番号</th><th>ステータス</th><th id="date-header" style="cursor:pointer;">日付</th><th style="width:20%;">履歴</th></tr>

--- a/web/today.js
+++ b/web/today.js
@@ -42,6 +42,15 @@ async function loadToday(page = 1) {
     if (c.order_id) return c.order_id.slice(0, 8) === todayKey;
     return false;
   });
+  const qEl = document.getElementById('quick-search');
+  const keyword = qEl ? qEl.value.trim() : '';
+  if (keyword) {
+    customers = customers.filter(c =>
+      (c.name || '').includes(keyword) ||
+      (c.phoneNumber || c.phone || '').includes(keyword) ||
+      (c.email || '').includes(keyword)
+    );
+  }
   customers.sort((a, b) =>
     sortDescending ? getKey(b) - getKey(a) : getKey(a) - getKey(b)
   );
@@ -128,5 +137,7 @@ window.addEventListener('DOMContentLoaded', () => {
       loadToday();
     });
   }
+  const qEl = document.getElementById('quick-search');
+  if (qEl) qEl.addEventListener('input', () => loadToday(1));
   loadToday();
 });


### PR DESCRIPTION
## Summary
- add quick-search input on all inquiries list and today's inquiries pages
- filter by name, phone or email in `all.js` and `today.js`
- update scripts to reload when the search text changes

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68474aaec924832a8018c52272918bbd