### PR TITLE
Update navigation with links and home button

### DIFF
--- a/web/nav.js
+++ b/web/nav.js
@@ -11,12 +11,18 @@ function showBreadcrumb() {
   const el = document.getElementById('breadcrumb');
   if (!el) return;
   let prev = '';
+  let prevPath = '';
   if (document.referrer && document.referrer.startsWith(window.location.origin)) {
     const url = new URL(document.referrer);
     prev = decodeURIComponent(url.pathname.split('/').pop());
+    prevPath = url.pathname.split('/').pop();
   }
   const current = decodeURIComponent(window.location.pathname.split('/').pop());
-  el.textContent = prev ? `${prev} > ${current}` : current;
+  if (prev) {
+    el.innerHTML = `<a href="${prevPath}">${prev}</a> &gt; ${current}`;
+  } else {
+    el.textContent = current;
+  }
 }
 
 document.addEventListener('DOMContentLoaded', showBreadcrumb);

--- a/web/today.html
+++ b/web/today.html
@@ -26,7 +26,10 @@
       </div>
     </div>
     <div id="breadcrumb" class="text-muted small mb-2"></div>
-    <a href="#" class="btn btn-secondary" onclick="goBack(event)">戻る</a>
+    <div class="d-flex align-items-center mb-3">
+      <a href="#" class="btn btn-secondary" onclick="goBack(event)">戻る</a>
+      <a href="index.html" class="btn btn-primary mx-auto">ホーム</a>
+    </div>
   </div>
   <footer class="text-center mt-4">
     <small style="color:#7ac142;">©2025 JIMUSURU All rights reserved.</small>


### PR DESCRIPTION
## Summary
- show link to previous page in breadcrumb
- add home button next to back button on today's page

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684753e1323c832a985d80c20abc980c