### PR TITLE
Add staff name field on detail page

### DIFF
--- a/web/detail.js
+++ b/web/detail.js
@@ -41,6 +41,7 @@ async function loadDetail() {
       ['name', '名前（顧客名）'],
       ['kana', 'カナ'],
       ['status', 'ステータス'],
+      ['staff', '担当者名'],
       ['phone', '電話番号'],
       ['email', 'メールアドレス'],
       ['type', 'お問い合わせ種別'],


### PR DESCRIPTION
## Summary
- show 担当者名 (staff name) on the customer detail page

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68475492d51c832aa2858fd117b82eef