### PR TITLE
Add body search and quick search features

### DIFF
--- a/web/pending.html
+++ b/web/pending.html
@@ -11,6 +11,9 @@
 <body class="p-4">
   <div class="container">
     <h1 class="mb-3">未済一覧</h1>
+    <div class="mb-3">
+      <input id="quick-search" class="form-control" placeholder="名前や電話番号、メールアドレスの一部をご入力してください。" />
+    </div>
 
     <table id="pending-table" class="table table-striped">
       <thead>

--- a/web/pending.js
+++ b/web/pending.js
@@ -35,6 +35,15 @@ async function loadPending(page = 1) {
   const res = await fetch(API + '/customers');
   const data = await res.json();
   let customers = (data.Items || data).filter(c => (c.status || '') === '未済');
+  const qEl = document.getElementById('quick-search');
+  const keyword = qEl ? qEl.value.trim() : '';
+  if (keyword) {
+    customers = customers.filter(c =>
+      (c.name || '').includes(keyword) ||
+      (c.phoneNumber || c.phone || '').includes(keyword) ||
+      (c.email || '').includes(keyword)
+    );
+  }
   customers.sort((a, b) =>
     sortDescending ? getKey(b) - getKey(a) : getKey(a) - getKey(b)
   );
@@ -124,5 +133,7 @@ window.addEventListener('DOMContentLoaded', () => {
       loadPending();
     });
   }
+  const qEl = document.getElementById('quick-search');
+  if (qEl) qEl.addEventListener('input', () => loadPending(1));
   loadPending();
 });

--- a/web/phone_today.html
+++ b/web/phone_today.html
@@ -11,6 +11,9 @@
 <body class="p-4">
   <div class="container">
     <h1 class="mb-3">本日の電話対応一覧</h1>
+    <div class="mb-3">
+      <input id="quick-search" class="form-control" placeholder="名前や電話番号、メールアドレスの一部をご入力してください。" />
+    </div>
     <table id="phone-table" class="table table-striped">
       <thead>
         <tr><th>名前</th><th>電話番号</th><th>ステータス</th><th id="date-header" style="cursor:pointer;">日付</th><th style="width:20%;">履歴</th></tr>

--- a/web/phone_today.js
+++ b/web/phone_today.js
@@ -44,6 +44,15 @@ async function loadPhoneToday(page = 1) {
     const isToday = c.date ? c.date === today : c.order_id && c.order_id.slice(0, 8) === todayKey;
     return isToday && (c.type || c.category) === '電話';
   });
+  const qEl = document.getElementById('quick-search');
+  const keyword = qEl ? qEl.value.trim() : '';
+  if (keyword) {
+    customers = customers.filter(c =>
+      (c.name || '').includes(keyword) ||
+      (c.phoneNumber || c.phone || '').includes(keyword) ||
+      (c.email || '').includes(keyword)
+    );
+  }
   customers.sort((a, b) =>
     sortDescending ? getKey(b) - getKey(a) : getKey(a) - getKey(b)
   );
@@ -130,5 +139,7 @@ window.addEventListener('DOMContentLoaded', () => {
       loadPhoneToday();
     });
   }
+  const qEl = document.getElementById('quick-search');
+  if (qEl) qEl.addEventListener('input', () => loadPhoneToday(1));
   loadPhoneToday();
 });

--- a/web/search.html
+++ b/web/search.html
@@ -50,6 +50,10 @@
         <summary class="btn btn-outline-secondary">バイク機種名</summary>
         <input id="s-details" class="form-control mt-2" />
       </details>
+      <details>
+        <summary class="btn btn-outline-secondary">本文検索</summary>
+        <input id="s-text" class="form-control mt-2" />
+      </details>
       <div class="align-self-end mt-2">
         <button class="btn btn-primary me-2" onclick="searchCustomers()">検索</button>
         <a class="btn btn-secondary" href="#" onclick="goBack(event)">戻る</a>

--- a/web/search.js
+++ b/web/search.js
@@ -8,6 +8,16 @@ let currentPage = 1;
 const PAGE_SIZE = 20;
 let searchResults = [];
 
+function hasText(customer, keyword) {
+  if ((customer.details || '').includes(keyword)) return true;
+  if (customer.history) {
+    for (const note of Object.values(customer.history)) {
+      if (typeof note === 'string' && note.includes(keyword)) return true;
+    }
+  }
+  return false;
+}
+
 async function searchCustomers(page = 1) {
   if (page === 1) {
     const dateInput = document.getElementById('s-date').value.trim();
@@ -18,6 +28,7 @@ async function searchCustomers(page = 1) {
     const status = document.getElementById('s-status').value.trim();
     const category = document.getElementById('s-category').value.trim();
     const details = document.getElementById('s-details').value.trim();
+    const text = document.getElementById('s-text').value.trim();
 
     const res = await fetch(API + '/customers');
     const data = await res.json();
@@ -30,7 +41,8 @@ async function searchCustomers(page = 1) {
       (!email || (c.email || '').includes(email)) &&
       (!status || (c.status || '') === status) &&
       (!category || (c.category || c.type || '') === category) &&
-      (!details || (c.details || '').includes(details))
+      (!details || (c.details || '').includes(details)) &&
+      (!text || hasText(c, text))
     );
 
     searchResults = customers;

--- a/web/visit_today.html
+++ b/web/visit_today.html
@@ -11,6 +11,9 @@
 <body class="p-4">
   <div class="container">
     <h1 class="mb-3">訪問対応一覧</h1>
+    <div class="mb-3">
+      <input id="quick-search" class="form-control" placeholder="名前や電話番号、メールアドレスの一部をご入力してください。" />
+    </div>
     <table id="visit-table" class="table table-striped">
       <thead>
         <tr><th>名前</th><th>電話番号</th><th>ステータス</th><th id="date-header" style="cursor:pointer;">日付</th><th style="width:20%;">履歴</th></tr>

--- a/web/visit_today.js
+++ b/web/visit_today.js
@@ -44,6 +44,15 @@ async function loadVisitToday(page = 1) {
     const isToday = c.date ? c.date === today : c.order_id && c.order_id.slice(0, 8) === todayKey;
     return isToday && (c.type || c.category) === '訪問対応';
   });
+  const qEl = document.getElementById('quick-search');
+  const keyword = qEl ? qEl.value.trim() : '';
+  if (keyword) {
+    customers = customers.filter(c =>
+      (c.name || '').includes(keyword) ||
+      (c.phoneNumber || c.phone || '').includes(keyword) ||
+      (c.email || '').includes(keyword)
+    );
+  }
   customers.sort((a, b) =>
     sortDescending ? getKey(b) - getKey(a) : getKey(a) - getKey(b)
   );
@@ -130,5 +139,7 @@ window.addEventListener('DOMContentLoaded', () => {
       loadVisitToday();
     });
   }
+  const qEl = document.getElementById('quick-search');
+  if (qEl) qEl.addEventListener('input', () => loadVisitToday(1));
   loadVisitToday();
 });


### PR DESCRIPTION
## Summary
- add text search input to advanced search page
- support searching history text in search results
- enable quick search on Pending, Phone Today, and Visit Today pages

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684be24130bc832a8c80d16075e03ef8