### PR TITLE
Add draft save message

### DIFF
--- a/web/add.html
+++ b/web/add.html
@@ -48,6 +48,7 @@
         <a class="btn btn-outline-info" href="drafts.html">一時保存一覧</a>
         <a class="btn btn-secondary" href="#" onclick="goBack(event)">キャンセル</a>
       </div>
+      <div id="save-status" class="mt-2 text-success"></div>
     </div>
   </div>
   <div id="breadcrumb" class="text-muted small mb-2"></div>

--- a/web/add.js
+++ b/web/add.js
@@ -17,6 +17,13 @@ function sanitizePhoneInput(e) {
 let autoSaveTimer = null;
 let currentItem = null;
 
+function showStatus(message) {
+  const el = document.getElementById('save-status');
+  if (!el) return;
+  el.textContent = message;
+  setTimeout(() => { el.textContent = ''; }, 3000);
+}
+
 async function saveCustomer(isDraft = false) {
   const note = document.getElementById('f-history-note').value.trim();
   const today = new Date(Date.now() + 9 * 60 * 60 * 1000)
@@ -77,6 +84,9 @@ async function saveCustomer(isDraft = false) {
       const data = await res.json();
       if (data.order_id) idField.value = data.order_id;
     }
+  }
+  if (isDraft) {
+    showStatus('一時保存しました');
   }
   if (!isDraft) {
     window.location.href = 'index.html';

--- a/web/style.css
+++ b/web/style.css
@@ -19,3 +19,7 @@
   color: #555;
   font-size: 0.9em;
 }
+
+#save-status {
+  min-height: 1.5em;
+}


### PR DESCRIPTION
## Summary
- display a save status area below the buttons on the add form
- show `一時保存しました` when saving a draft
- add minimal styling for the new status area

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684bf1c084e8832a8067344132149748