### PR TITLE
Add memo template with placeholder

### DIFF
--- a/web/add.html
+++ b/web/add.html
@@ -41,7 +41,10 @@
       </div>
 
       <div class="mb-2">担当: <input id="f-staff" class="form-control" /></div>
-      <div class="mb-2">メモ: <textarea id="f-history-note" class="form-control" rows="12"></textarea></div>
+      <div class="mb-2">メモ:
+        <textarea id="f-history-note" class="form-control" rows="12" placeholder="【お客様のご用件】&#10;&#10;【担当者】&#10;担当者のメモをここに打つ"></textarea>
+        <button type="button" class="btn btn-outline-secondary mt-2" onclick="insertTemplate()">テンプレートを挿入</button>
+      </div>
 
       <div>
         <button class="btn btn-primary" onclick="saveCustomer()">保存</button>

--- a/web/add.js
+++ b/web/add.js
@@ -17,6 +17,18 @@ function sanitizePhoneInput(e) {
 let autoSaveTimer = null;
 let currentItem = null;
 
+const HISTORY_TEMPLATE = `【お客様のご用件】\n\n【担当者】\n担当者のメモをここに打つ`;
+
+function insertTemplate() {
+  const field = document.getElementById('f-history-note');
+  if (!field) return;
+  if (field.value.trim() &&
+      !confirm('テンプレートを挿入すると現在の入力が失われます。よろしいですか？')) {
+    return;
+  }
+  field.value = HISTORY_TEMPLATE;
+}
+
 function showStatus(message) {
   const el = document.getElementById('save-status');
   if (!el) return;

--- a/web/edit.html
+++ b/web/edit.html
@@ -33,7 +33,10 @@
         </select>
       </div>
       <div class="mb-2">担当: <input id="f-staff" class="form-control" /></div>
-      <div class="mb-2">メモ: <textarea id="f-history-note" class="form-control" rows="12"></textarea></div>
+      <div class="mb-2">メモ:
+        <textarea id="f-history-note" class="form-control" rows="12" placeholder="【お客様のご用件】&#10;&#10;【担当者】&#10;担当者のメモをここに打つ"></textarea>
+        <button type="button" class="btn btn-outline-secondary mt-2" onclick="insertTemplate()">テンプレートを挿入</button>
+      </div>
       <div id="history-view" class="mb-2"></div>
       <div>
         <button class="btn btn-primary" onclick="saveCustomer()">保存</button>

--- a/web/edit.js
+++ b/web/edit.js
@@ -4,6 +4,18 @@ const API = (typeof window !== 'undefined' && window.API_URL) ||
 
 let currentItem = null;
 
+const HISTORY_TEMPLATE = `【お客様のご用件】\n\n【担当者】\n担当者のメモをここに打つ`;
+
+function insertTemplate() {
+  const field = document.getElementById('f-history-note');
+  if (!field) return;
+  if (field.value.trim() &&
+      !confirm('テンプレートを挿入すると現在の入力が失われます。よろしいですか？')) {
+    return;
+  }
+  field.value = HISTORY_TEMPLATE;
+}
+
 async function loadCustomer() {
   const params = new URLSearchParams(location.search);
   const id = params.get('id');


### PR DESCRIPTION
## Summary
- add memo template placeholder to add/edit forms
- provide `テンプレートを挿入` buttons with confirmation

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684bfc117014832a8953c1ad41ff4e10