### PR TITLE
Remove history view from edit screen

### DIFF
--- a/web/edit.html
+++ b/web/edit.html
@@ -37,7 +37,6 @@
         <textarea id="f-history-note" class="form-control" rows="12" placeholder="【お客様のご用件】&#10;&#10;【担当者】&#10;担当者のメモをここに打つ"></textarea>
         <button type="button" class="btn btn-outline-secondary mt-2" onclick="insertTemplate()">テンプレートを挿入</button>
       </div>
-      <div id="history-view" class="mb-2"></div>
       <div>
         <button class="btn btn-primary" onclick="saveCustomer()">保存</button>
         <a class="btn btn-secondary" href="#" onclick="goBack(event)">キャンセル</a>

--- a/web/edit.js
+++ b/web/edit.js
@@ -37,20 +37,12 @@ async function loadCustomer() {
   document.getElementById('f-status').value = item.status || '未済';
   document.getElementById('f-staff').value = item.staff || '';
   const noteField = document.getElementById('f-history-note');
-  const hv = document.getElementById('history-view');
   noteField.value = '';
-  hv.innerHTML = '';
   if (item.history) {
     const entries = Object.entries(item.history).sort(([a], [b]) => a.localeCompare(b));
     if (entries.length) {
       noteField.value = entries[entries.length - 1][1];
     }
-    entries.forEach(([d, n]) => {
-      const div = document.createElement('div');
-      div.style.whiteSpace = 'pre-wrap';
-      div.textContent = `${d}: ${n}`;
-      hv.appendChild(div);
-    });
   }
 }
 


### PR DESCRIPTION
## Summary
- remove the history notes viewer from `edit.html`
- stop populating the removed history viewer in `edit.js`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684c003fdd9c832aa1d05ca8be408af4