### PR TITLE
Add home buttons to lists and search

### DIFF
--- a/web/completed.html
+++ b/web/completed.html
@@ -29,7 +29,10 @@
       </div>
     </div>
     <div id="breadcrumb" class="text-muted small mb-2"></div>
-    <a href="#" class="btn btn-secondary" onclick="goBack(event)">戻る</a>
+    <div class="d-flex align-items-center mb-3">
+      <a href="#" class="btn btn-secondary" onclick="goBack(event)">戻る</a>
+      <a href="index.html" class="btn btn-primary mx-auto">ホーム</a>
+    </div>
   </div>
   <footer class="text-center mt-4">
     <small style="color:#7ac142;">©2025 JIMUSURU All rights reserved.</small>

--- a/web/pending.html
+++ b/web/pending.html
@@ -36,7 +36,10 @@
       </div>
     </div>
     <div id="breadcrumb" class="text-muted small mb-2"></div>
-    <a href="#" class="btn btn-secondary" onclick="goBack(event)">戻る</a>
+    <div class="d-flex align-items-center mb-3">
+      <a href="#" class="btn btn-secondary" onclick="goBack(event)">戻る</a>
+      <a href="index.html" class="btn btn-primary mx-auto">ホーム</a>
+    </div>
   </div>
 
   <footer class="text-center mt-4">

--- a/web/phone_today.html
+++ b/web/phone_today.html
@@ -29,7 +29,10 @@
       </div>
     </div>
     <div id="breadcrumb" class="text-muted small mb-2"></div>
-    <a href="#" class="btn btn-secondary" onclick="goBack(event)">戻る</a>
+    <div class="d-flex align-items-center mb-3">
+      <a href="#" class="btn btn-secondary" onclick="goBack(event)">戻る</a>
+      <a href="index.html" class="btn btn-primary mx-auto">ホーム</a>
+    </div>
   </div>
   <footer class="text-center mt-4">
     <small style="color:#7ac142;">©2025 JIMUSURU All rights reserved.</small>

--- a/web/search.html
+++ b/web/search.html
@@ -66,14 +66,18 @@
       </thead>
       <tbody></tbody>
     </table>
-    <div class="row mb-3">
-      <div class="col-12 d-flex justify-content-between align-items-center">
-        <button id="prev-btn" class="btn btn-outline-primary btn-sm" onclick="prevPage()">前へ</button>
-        <span id="page-info">1 / 1</span>
-        <button id="next-btn" class="btn btn-outline-primary btn-sm" onclick="nextPage()">次へ</button>
+      <div class="row mb-3">
+        <div class="col-12 d-flex justify-content-between align-items-center">
+          <button id="prev-btn" class="btn btn-outline-primary btn-sm" onclick="prevPage()">前へ</button>
+          <span id="page-info">1 / 1</span>
+          <button id="next-btn" class="btn btn-outline-primary btn-sm" onclick="nextPage()">次へ</button>
+        </div>
+      </div>
+      <div class="d-flex align-items-center mb-3">
+        <a href="#" class="btn btn-secondary" onclick="goBack(event)">戻る</a>
+        <a href="index.html" class="btn btn-primary mx-auto">ホーム</a>
       </div>
     </div>
-  </div>
   <footer class="text-center mt-4">
     <small style="color:#7ac142;">©2025 JIMUSURU All rights reserved.</small>
   </footer>

--- a/web/visit_today.html
+++ b/web/visit_today.html
@@ -29,7 +29,10 @@
       </div>
     </div>
     <div id="breadcrumb" class="text-muted small mb-2"></div>
-    <a href="#" class="btn btn-secondary" onclick="goBack(event)">戻る</a>
+    <div class="d-flex align-items-center mb-3">
+      <a href="#" class="btn btn-secondary" onclick="goBack(event)">戻る</a>
+      <a href="index.html" class="btn btn-primary mx-auto">ホーム</a>
+    </div>
   </div>
   <footer class="text-center mt-4">
     <small style="color:#7ac142;">©2025 JIMUSURU All rights reserved.</small>


### PR DESCRIPTION
## Summary
- add back & home buttons after breadcrumb on list pages
- add same navigation buttons at the bottom of search results

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684f569177b8832ab5302b796c1cde0f