### PR TITLE
Clarify bike field in forms

### DIFF
--- a/web/add.html
+++ b/web/add.html
@@ -31,7 +31,7 @@
       </div>
 
       <div class="mb-2">電話番号: <input id="f-phone" class="form-control" /></div>
-      <div class="mb-2">詳細: <input id="f-details" class="form-control" /></div>
+      <div class="mb-2">バイク名など: <input id="f-details" class="form-control" placeholder="バイク名などを入力してください" /></div>
 
       <div class="mb-2">ステータス:
         <select id="f-status" class="form-select" disabled>

--- a/web/edit.html
+++ b/web/edit.html
@@ -25,7 +25,7 @@
         </select>
       </div>
       <div class="mb-2">電話番号: <input id="f-phone" class="form-control" /></div>
-      <div class="mb-2">詳細: <input id="f-details" class="form-control" /></div>
+      <div class="mb-2">バイク名など: <input id="f-details" class="form-control" placeholder="バイク名などを入力してください" /></div>
       <div class="mb-2">ステータス:
         <select id="f-status" class="form-select">
           <option value="未済">未済</option>


### PR DESCRIPTION
## Summary
- clarify "詳細" field by renaming it to "バイク名など" and adding a placeholder

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684f575f696c832aaf73173f708e65e7