### PR TITLE
Implement central resizable layout

### DIFF
--- a/web/index.html
+++ b/web/index.html
@@ -25,9 +25,9 @@
       </div>
     </div>
 
-    <div class="row mb-3">
+    <div id="split-container" class="d-flex mb-3 flex-nowrap">
       <!-- Dashboard Area -->
-      <div id="dashboard" class="col-md-6 mb-3 mb-md-0" style="height:600px; overflow:auto; resize: horizontal;">
+      <div id="dashboard" class="flex-grow-1 p-0" style="height:600px; overflow:auto;">
         <div id="dashboard-metrics" class="row row-cols-2 g-2 mb-3">
           <div class="col">
             <a href="all.html" class="text-decoration-none">
@@ -110,8 +110,10 @@
 
       </div>
 
+      <div id="divider" class="flex-shrink-0 p-0" style="width:5px; cursor:ew-resize; background:#eee;"></div>
+
       <!-- Mail Area -->
-      <div id="mail" class="col-md-6" style="height:600px; resize: horizontal; overflow:auto;">
+      <div id="mail" class="flex-grow-1 p-0" style="height:600px; overflow:auto;">
         <div class="d-flex flex-column h-100">
           <div class="border flex-fill p-3 mb-2">メール</div>
           <div class="border flex-fill p-3">受電履歴（アイブリー）</div>
@@ -153,5 +155,6 @@
     </footer>
 
     <script src="app.js"></script>
+    <script src="split.js"></script>
   </body>
 </html>

--- a/web/split.js
+++ b/web/split.js
@@ -1,0 +1,31 @@
+// Enable draggable divider between dashboard and mail sections
+
+document.addEventListener('DOMContentLoaded', () => {
+  const container = document.getElementById('split-container');
+  const left = document.getElementById('dashboard');
+  const right = document.getElementById('mail');
+  const divider = document.getElementById('divider');
+  if (!container || !left || !right || !divider) return;
+
+  function onDrag(e) {
+    const rect = container.getBoundingClientRect();
+    const offset = e.clientX - rect.left;
+    const min = 100;
+    const max = rect.width - 100;
+    const leftWidth = Math.max(min, Math.min(max, offset));
+    const leftPercent = (leftWidth / rect.width) * 100;
+    left.style.width = leftPercent + '%';
+    right.style.width = 100 - leftPercent + '%';
+  }
+
+  function stopDrag() {
+    document.removeEventListener('mousemove', onDrag);
+    document.removeEventListener('mouseup', stopDrag);
+  }
+
+  divider.addEventListener('mousedown', e => {
+    e.preventDefault();
+    document.addEventListener('mousemove', onDrag);
+    document.addEventListener('mouseup', stopDrag);
+  });
+});

--- a/web/style.css
+++ b/web/style.css
@@ -33,3 +33,20 @@
 #detail-table th {
   background-color: #f8f9fa;
 }
+
+/* Split container for dashboard and mail */
+#split-container {
+  width: 100%;
+}
+
+#dashboard,
+#mail {
+  width: 50%;
+  flex-shrink: 0;
+}
+
+#divider {
+  width: 5px;
+  background: #eee;
+  cursor: ew-resize;
+}


### PR DESCRIPTION
## Summary
- make dashboard and mail area share a single flex container
- add draggable divider to resize the two blocks while keeping 100% width
- style new split container in CSS
- add JavaScript to handle dragging

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684f58260f90832ab8b618ca7c0e2eb7