### PR TITLE
Switch to cheapest GPT model

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,6 +136,7 @@ API Gateway triggers the `handler` exported from `lambda.js`.
 
 `/summary` エンドポイントで本日の未済タスクを取得し、OpenAI API を用いて要約文を返します。
 環境変数 `OPENAI_API_KEY` に API キーを設定してください。
+このサンプルでは最も低コストな `gpt-3.5-turbo-0125` モデルを使用します。
 トップページの「AI要約」ボタンから呼び出し、結果をダイアログ表示します。
 
 

--- a/app.js
+++ b/app.js
@@ -184,7 +184,7 @@ app.get('/summary', async (req, res) => {
         Authorization: `Bearer ${key}`
       },
       body: JSON.stringify({
-        model: 'gpt-3.5-turbo',
+        model: 'gpt-3.5-turbo-0125',
         messages: [{ role: 'user', content: prompt }],
         temperature: 0.7
       })


### PR DESCRIPTION
## Summary
- use model `gpt-3.5-turbo-0125` for the summary endpoint
- document the chosen model in the README

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684f7587a94c832a9d898c902921f794