### PR TITLE
Improve error details for goobike routes

### DIFF
--- a/web/goobike_additional.js
+++ b/web/goobike_additional.js
@@ -24,16 +24,18 @@ async function loadEmails() {
     return;
   }
 
+  if (!res.ok) {
+    const msg = data.error || data.message || res.statusText || 'Failed to fetch';
+    console.error(msg);
+    displayError(msg);
+    return;
+  }
+
   const items = Array.isArray(data.Items) ? data.Items : Array.isArray(data) ? data : [];
   const tbody = document.querySelector('#goobike-table tbody');
   tbody.innerHTML = '';
 
   if (!items.length) {
-    if (!res.ok) {
-      const msg = data.error || data.message || res.statusText || 'Failed to fetch';
-      console.error(msg);
-      displayError(msg);
-    }
     return;
   }
 
@@ -55,9 +57,15 @@ document.addEventListener('DOMContentLoaded', () => {
     const btn = document.getElementById('fetch-btn');
     btn.disabled = true;
     try {
-      await fetch(API + '/api/fetch-email');
+      const res = await fetch(API + '/api/fetch-email');
+      const data = await res.json().catch(() => ({}));
+      if (!res.ok) {
+        const msg = data.error || data.message || res.statusText || 'Failed to fetch';
+        displayError(msg);
+      }
     } catch (err) {
       console.error(err);
+      displayError('メールの取得に失敗しました');
     }
     await loadEmails();
     btn.disabled = false;


### PR DESCRIPTION
## Summary
- include `respondError` helper in server
- return more detailed errors from `/api/fetch-email` and `/goobike-emails`
- surface server errors to users in `goobike_additional.js`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684f7a4cebc4832aaccaca827012144d