### PR TITLE
Limit body text display in GooBike additional messages

### DIFF
--- a/web/goobike_additional.js
+++ b/web/goobike_additional.js
@@ -41,12 +41,14 @@ async function loadEmails() {
 
   items.forEach(item => {
     const tr = document.createElement('tr');
+    let bodySnippet = item.body || '';
+    if (bodySnippet.length > 200) bodySnippet = bodySnippet.slice(0, 200) + '…';
     tr.innerHTML = `
       <td>${item.inquiry_id}</td>
       <td>${escapeHtml(item.name || '')}</td>
       <td>${escapeHtml(item.email || '')}</td>
       <td>${escapeHtml(item.phone || '')}</td>
-      <td style="white-space:pre-wrap;">${escapeHtml(item.body || '')}</td>
+      <td style="white-space:pre-wrap;">${escapeHtml(bodySnippet)}</td>
       <td>${item.createdAt || ''}</td>`;
     tbody.appendChild(tr);
   });


### PR DESCRIPTION
## Summary
- truncate GooBike additional message body to 200 chars with ellipsis

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684f8669fd20832a9cec1e568f4da932